### PR TITLE
Fix ts-jest config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,7 @@
         "@types/express-session": "^1.18.1",
         "@types/helmet": "^0.0.48",
         "@types/jest": "^29.5.14",
+        "@types/jsdom": "^21.1.7",
         "@types/jwt-decode": "^2.2.1",
         "@types/logform": "^1.2.0",
         "@types/morgan": "^1.9.10",
@@ -7109,6 +7110,18 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7431,6 +7444,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "ts-jest",
         {
           "useESM": true,
-          "tsconfig": "tsconfig.json"
+          "tsconfig": "tsconfig.test.json"
         }
       ]
     },
@@ -189,6 +189,7 @@
     "@types/express-session": "^1.18.1",
     "@types/helmet": "^0.0.48",
     "@types/jest": "^29.5.14",
+    "@types/jsdom": "^21.1.7",
     "@types/jwt-decode": "^2.2.1",
     "@types/logform": "^1.2.0",
     "@types/morgan": "^1.9.10",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import {
   users,
   organizations,
+  trips,
+  activities,
   todos,
   notes,
   invitations,
@@ -31,6 +33,27 @@ import {
 // invitations, organizationRoles, organizationMembers, tripCollaborators
 // are imported from '../server/db/schema'.
 // Other table definitions below will be moved progressively.
+
+// Re-export commonly used tables and schemas for backward compatibility
+export {
+  users,
+  organizations,
+  trips,
+  activities,
+  todos,
+  notes,
+  invitations,
+  organizationRoles,
+  organizationMembers,
+  tripCollaborators,
+  tripComments,
+  insertTripSchema,
+  selectTripSchema,
+  insertActivitySchema,
+  selectActivitySchema,
+  insertTripCommentSchema,
+  selectTripCommentSchema,
+} from "../server/db/schema";
 
 // Re-export types from server/db/schema for consistent usage
 export type {
@@ -656,7 +679,6 @@ export type UserActivityLog = typeof userActivityLogs.$inferSelect;
 // Trip Collaboration Types
 // export type TripCollaboration = typeof tripCollaborators.$inferSelect; // TripCollaborator type is already re-exported from server/db/schema
 export type { TripComment, NewTripComment }; // Re-exporting types imported above
-export { insertTripCommentSchema, selectTripCommentSchema }; // Re-exporting Zod schemas imported above
 // The .omit logic for insertTripCommentSchema should ideally be in server/db/schema.ts if it's the standard schema.
 // If a specific variant is needed here, it would require createInsertSchema and tripComments to be available/imported.
 // For now, re-exporting the standard schemas from server/db/schema.ts.
@@ -697,7 +719,6 @@ export { insertTripCommentSchema, selectTripCommentSchema }; // Re-exporting Zod
 // export type InsertBillingEvent = z.infer<typeof insertBillingEventSchema>;
 */
 
-export { insertTripSchema, selectTripSchema, insertActivitySchema, selectActivitySchema };
 
 // User roles constants
 export const USER_ROLES = {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["jest", "node"],
-    "module": "CommonJS",
-    "moduleResolution": "node"
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["es2017", "esnext", "dom"]
   },
   "include": ["tests/**/*"],
   "exclude": ["node_modules"]
-} 
+}


### PR DESCRIPTION
## Summary
- ensure Jest uses tsconfig.test.json
- add DOM lib and ESNext modules for Jest TS config
- expose tables from shared schema for compatibility
- install `@types/jsdom`

## Testing
- `npm run test` *(fails: cannot find module configureCORS, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d97f55883238c96a3c59a5b1768