### PR TITLE
Fix import paths and CSS utilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,8 @@
         "vite": "^5.0.12"
       },
       "devDependencies": {
-        "@types/crypto-js": "^4.2.2"
+        "@types/crypto-js": "^4.2.2",
+        "@types/node": "^24.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1354,6 +1355,16 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
@@ -1817,6 +1828,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.2.2"
+    "@types/crypto-js": "^4.2.2",
+    "@types/node": "^24.0.3"
   }
 }

--- a/client/src/components/navigation/MainNavigation.tsx
+++ b/client/src/components/navigation/MainNavigation.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'wouter';
-import { MenuIcon, XIcon } from '../Icons';
-import { useAuth } from '../../contexts/AuthContext';
+import { MenuIcon, XIcon } from '../icons';
+import { useAuth } from '../../contexts/auth/AuthContext';
 import { useNotifications } from '../../hooks/useNotifications';
 import { MobileMenu } from './MobileMenu';
 import { DesktopNavigation } from './DesktopNavigation';

--- a/client/src/components/navigation/MobileMenu.tsx
+++ b/client/src/components/navigation/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { XIcon } from '../Icons';
+import { XIcon } from '../icons';
 import { NavigationLink } from './NavigationLink';
 import { MobileMenuProps } from './types';
 

--- a/client/src/components/navigation/NotificationsMenu.tsx
+++ b/client/src/components/navigation/NotificationsMenu.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { BellIcon } from '../Icons';
+import { BellIcon } from '../icons';
 import { NotificationsMenuProps } from './types';
 
 export const NotificationsMenu: React.FC<NotificationsMenuProps> = ({

--- a/client/src/components/navigation/UserMenu.tsx
+++ b/client/src/components/navigation/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { UserIcon } from '../Icons';
+import { UserIcon } from '../icons';
 import { UserMenuProps } from './types';
 
 export const UserMenu: React.FC<UserMenuProps> = ({

--- a/client/src/contexts/WhiteLabelContext.tsx
+++ b/client/src/contexts/WhiteLabelContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { useAuthContext as useAuth } from './SecureJWTAuthContext';
+import { useAuthContext as useAuth } from './auth/AuthContext';
 import { useLocation } from 'wouter';
 import { useQuery } from '@tanstack/react-query';
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -251,7 +251,7 @@ button {
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
 
   html {
@@ -260,7 +260,9 @@ button {
   }
 
   body {
-    @apply font-sans antialiased bg-background text-foreground;
+    @apply font-sans antialiased;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
     letter-spacing: -0.01em;
     height: 100%;
@@ -270,7 +272,8 @@ button {
 
   /* Navan-style typography */
   h1, h2, h3, h4, h5, h6 {
-    @apply text-foreground font-semibold;
+    color: hsl(var(--foreground));
+    @apply font-semibold;
     letter-spacing: -0.02em;
   }
 
@@ -302,7 +305,9 @@ button {
 
   /* Modern focus styles */
   :focus-visible {
-    @apply outline-none ring-2 ring-electric-500/50 ring-offset-2 ring-offset-background;
+    @apply outline-none ring-2 ring-offset-2;
+    --tw-ring-color: hsl(var(--electric-500) / 0.5);
+    --tw-ring-offset-color: hsl(var(--background));
   }
 
   /* Custom scrollbar */
@@ -312,15 +317,16 @@ button {
   }
 
   ::-webkit-scrollbar-track {
-    @apply bg-muted/50;
+    background-color: hsl(var(--muted) / 0.5);
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-muted-foreground/30 rounded-full;
+    background-color: hsl(var(--muted-foreground) / 0.3);
+    border-radius: 0.25rem;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-muted-foreground/50;
+    background-color: hsl(var(--muted-foreground) / 0.5);
   }
 }
 
@@ -362,20 +368,25 @@ button {
 
 /* Switch components */
 button[role="switch"] {
-  @apply border-2 border-border shadow-sm;
+  @apply border-2 shadow-sm;
+  border-color: hsl(var(--border));
 }
 
 button[role="switch"][data-state="checked"] {
-  @apply bg-primary border-primary;
+  border-color: hsl(var(--primary));
+  background-color: hsl(var(--primary));
 }
 
 button[role="switch"][data-state="unchecked"] {
-  @apply bg-muted border-border;
+  background-color: hsl(var(--muted));
+  border-color: hsl(var(--border));
 }
 
 /* Input and form elements */
 input[type="text"], input[type="email"], input[type="password"], input[type="number"], textarea, select {
-  @apply border border-border bg-background;
+  @apply border;
+  background-color: hsl(var(--background));
+  border-color: hsl(var(--border));
 }
 
 /* Prevent iOS zoom on input focus */
@@ -426,7 +437,8 @@ input[type="text"], input[type="email"], input[type="password"], input[type="num
 
 /* Badge components */
 .badge {
-  @apply border border-border/50 shadow-sm;
+  @apply border shadow-sm;
+  border-color: hsl(var(--border) / 0.5);
 }
 
 /* Mobile responsive adjustments */


### PR DESCRIPTION
## Summary
- fix import in `WhiteLabelContext` after file rename
- change navigation imports to lowercase `icons` path
- clarify color utility classes in `index.css`
- add missing `@types/node` dependency

## Testing
- `npm test` *(fails: Cannot find name 'describe', missing jest typings)*
- `npm --prefix client run build` *(fails: Could not resolve ./time-picker)*

------
https://chatgpt.com/codex/tasks/task_e_685010be6eac8323a248923d1d7e2ad3