### PR TITLE
Integrate B2B pages and invoice query

### DIFF
--- a/client/src/components/icons/index.tsx
+++ b/client/src/components/icons/index.tsx
@@ -62,3 +62,11 @@ export const CogIcon = createIcon(
 export const LogoutIcon = createIcon(
   'M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1'
 );
+
+export const CheckIcon = createIcon(
+  'M5 13l4 4L19 7'
+);
+
+export const FileTextIcon = createIcon(
+  'M12 1H6a2 2 0 00-2 2v18a2 2 0 002 2h12a2 2 0 002-2V7l-6-6zM14 2v6h6M16 13H8m8 4H8m0-8h.01'
+);

--- a/client/src/components/navigation/MainNavigation.tsx
+++ b/client/src/components/navigation/MainNavigation.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'wouter';
-import { MenuIcon, XIcon } from '../icons';
+import { MenuIcon, XIcon, BarChartIcon, CheckIcon, FileTextIcon, HomeIcon } from '../icons';
 import { useAuth } from '../../contexts/auth/AuthContext';
 import { useNotifications } from '../../hooks/useNotifications';
 import { MobileMenu } from './MobileMenu';
@@ -25,19 +25,40 @@ export const MainNavigation: React.FC = () => {
 
   // Navigation items
   const navigationItems: NavigationItem[] = [
-    { 
-      name: 'Home', 
-      href: '/', 
+    {
+      name: 'Home',
+      href: '/',
       icon: <HomeIcon className="h-5 w-5" aria-hidden="true" />,
       ariaLabel: 'Home',
-      requiresAuth: false 
+      requiresAuth: false
     },
-    { 
-      name: 'Dashboard', 
-      href: '/dashboard', 
+    {
+      name: 'Dashboard',
+      href: '/dashboard',
       icon: <BarChartIcon className="h-5 w-5" aria-hidden="true" />,
       ariaLabel: 'Dashboard',
-      requiresAuth: true 
+      requiresAuth: true
+    },
+    {
+      name: 'Analytics',
+      href: '/analytics',
+      icon: <BarChartIcon className="h-5 w-5" aria-hidden="true" />,
+      ariaLabel: 'Analytics',
+      requiresAuth: true
+    },
+    {
+      name: 'Approvals',
+      href: '/approvals',
+      icon: <CheckIcon className="h-5 w-5" aria-hidden="true" />,
+      ariaLabel: 'Approvals',
+      requiresAuth: true
+    },
+    {
+      name: 'Invoices',
+      href: '/invoice-center',
+      icon: <FileTextIcon className="h-5 w-5" aria-hidden="true" />,
+      ariaLabel: 'Invoices',
+      requiresAuth: true
     },
   ];
 

--- a/client/src/config/routes.ts
+++ b/client/src/config/routes.ts
@@ -75,6 +75,20 @@ export const protectedRoutes: RouteObject[] = [
     element: lazyLoad(() => import('@/pages/AITripGenerator')),
   },
 
+  // B2B feature routes
+  {
+    path: '/analytics',
+    element: lazyLoad(() => import('@/pages/Analytics')),
+  },
+  {
+    path: '/approvals',
+    element: lazyLoad(() => import('@/pages/Approvals')),
+  },
+  {
+    path: '/invoice-center',
+    element: lazyLoad(() => import('@/pages/InvoiceCenter')),
+  },
+
   // Invoice routes
   {
     path: '/invoice/:id',

--- a/client/src/pages/InvoiceCenter.tsx
+++ b/client/src/pages/InvoiceCenter.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -87,6 +88,19 @@ export default function InvoiceCenter() {
       taxRate: 0
     }
   });
+
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const proposalId = searchParams.get('proposalId');
+    if (proposalId && proposals) {
+      const proposal = proposals.find((p: any) => String(p.id) === proposalId);
+      if (proposal) {
+        convertProposalToInvoice(proposal);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, proposals]);
 
   const convertProposalToInvoice = (proposal: any) => {
     setSelectedProposal(proposal);

--- a/plan.md
+++ b/plan.md
@@ -18,4 +18,18 @@
 - [ ] Add sample orgs and proposals for demo [optional]
 - [ ] Implement proposal analytics (opens/views) [optional]
 
+## 🚀 B2B Feature Integration Plan
+
+The following pages were identified as unused but represent important B2B functionality:
+
+- `Analytics.tsx` – business intelligence dashboard for organizations
+- `Approvals.tsx` – manage travel approvals and corporate policies
+- `InvoiceCenter.tsx` – central location for proposal invoicing
+
+### Tasks
+1. **Route Integration** – expose the above pages at `/analytics`, `/approvals`, and `/invoice-center` in `client/src/config/routes.ts`.
+2. **Navigation Links** – add corresponding navigation items in `MainNavigation` so corporate users can access them.
+3. **Superadmin Cleanup** – keep `SuperadminClean.tsx` as the active superadmin portal and do not reintroduce outdated versions.
+4. **Testing** – verify the new routes render properly and navigation works when logged in.
+
 ## 🧠 See notes.md for full technical notes


### PR DESCRIPTION
## Summary
- add B2B feature routes and navigation items
- create icons for approvals and invoices
- prefill Invoice Center from `proposalId` query parameter

## Testing
- `npm test` *(fails: TypeScript errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_685024343ba4832394f3fe8cb46aaab3