### PR TITLE
Standardize electric violet styles

### DIFF
--- a/client/src/components/AITripGenerator.tsx
+++ b/client/src/components/AITripGenerator.tsx
@@ -362,7 +362,7 @@ export default function AITripGenerator() {
         
         <Card className="p-4">
           <div className="flex items-center space-x-3">
-            <DollarSign className="w-5 h-5 text-purple-600" />
+            <DollarSign className="w-5 h-5 text-electric-600" />
             <div>
               <h3 className="font-medium">Budget Planning</h3>
               <p className="text-sm text-gray-600">Detailed cost breakdown and optimization</p>
@@ -416,8 +416,8 @@ function TripResultsView({ trip, onBack }: { trip: GeneratedTrip; onBack: () => 
               <div className="text-sm font-medium">Total Cost</div>
               <div className="text-lg font-bold">${trip.tripSummary?.totalCost || 0}</div>
             </div>
-            <div className="text-center p-3 bg-purple-50 rounded-lg">
-              <TrendingUp className="w-6 h-6 text-purple-600 mx-auto mb-1" />
+            <div className="text-center p-3 bg-electric-50 rounded-lg">
+              <TrendingUp className="w-6 h-6 text-electric-600 mx-auto mb-1" />
               <div className="text-sm font-medium">Activities</div>
               <div className="text-lg font-bold">{trip.activities?.length || 0}</div>
             </div>
@@ -451,7 +451,7 @@ function TripResultsView({ trip, onBack }: { trip: GeneratedTrip; onBack: () => 
               ))}
 
               <h3 className="text-lg font-semibold flex items-center space-x-2">
-                <Bed className="w-5 h-5 text-purple-600" />
+                <Bed className="w-5 h-5 text-electric-600" />
                 <span>Accommodation</span>
               </h3>
               {trip.accommodation?.map((hotel: Accommodation, index: number) => (

--- a/client/src/components/AnalyticsDashboard.tsx
+++ b/client/src/components/AnalyticsDashboard.tsx
@@ -434,8 +434,8 @@ export default function AnalyticsDashboard() {
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
-                  <Activity className="h-4 w-4 text-purple-600" />
+                <div className="w-8 h-8 bg-electric-100 rounded-full flex items-center justify-center">
+                  <Activity className="h-4 w-4 text-electric-600" />
                 </div>
                 <span className="font-medium">Added Activities</span>
               </div>
@@ -470,8 +470,8 @@ export default function AnalyticsDashboard() {
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center">
-                  <Download className="h-4 w-4 text-indigo-600" />
+                <div className="w-8 h-8 bg-electric-100 rounded-full flex items-center justify-center">
+                  <Download className="h-4 w-4 text-electric-600" />
                 </div>
                 <span className="font-medium">Exported Data</span>
               </div>
@@ -496,7 +496,7 @@ export default function AnalyticsDashboard() {
             </div>
             <div className="text-center">
               <div className="text-sm text-muted-foreground">Activity Rate</div>
-              <div className="text-xl font-bold text-purple-600">
+              <div className="text-xl font-bold text-electric-600">
                 {Math.round((analytics.userFunnel.usersWithActivities / analytics.userFunnel.totalUsers) * 100)}%
               </div>
             </div>
@@ -508,7 +508,7 @@ export default function AnalyticsDashboard() {
             </div>
             <div className="text-center">
               <div className="text-sm text-muted-foreground">Export Rate</div>
-              <div className="text-xl font-bold text-indigo-600">
+              <div className="text-xl font-bold text-electric-600">
                 {Math.round((analytics.userFunnel.usersWithExports / analytics.userFunnel.totalUsers) * 100)}%
               </div>
             </div>

--- a/client/src/components/BillingDashboard.tsx
+++ b/client/src/components/BillingDashboard.tsx
@@ -126,7 +126,7 @@ export default function BillingDashboard() {
 
   const getPlanColor = (plan: string) => {
     switch (plan) {
-      case 'enterprise': return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300';
+      case 'enterprise': return 'bg-electric-100 text-electric-800 dark:bg-electric-900 dark:text-electric-300';
       case 'team': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
       default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
     }
@@ -290,7 +290,7 @@ export default function BillingDashboard() {
           </Card>
 
           {/* Enterprise Plan */}
-          <Card className={billingInfo?.plan === 'enterprise' ? 'ring-2 ring-purple-500' : ''}>
+          <Card className={billingInfo?.plan === 'enterprise' ? 'ring-2 ring-electric-500' : ''}>
             <CardHeader>
               <CardTitle className="flex items-center justify-between">
                 Enterprise

--- a/client/src/components/CalendarIntegration.tsx
+++ b/client/src/components/CalendarIntegration.tsx
@@ -208,7 +208,7 @@ export default function CalendarIntegration() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <Settings className="h-8 w-8 text-purple-600" />
+                <Settings className="h-8 w-8 text-electric-600" />
                 <div>
                   <div className="font-medium">Quick Sync</div>
                   <div className="text-sm text-slate-600 dark:text-slate-400">

--- a/client/src/components/CarbonExpenseTracker.tsx
+++ b/client/src/components/CarbonExpenseTracker.tsx
@@ -137,13 +137,13 @@ export default function CarbonExpenseTracker({ tripId, activities, budget }: Car
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-600 dark:text-gray-300">vs Average Trip</p>
-                <p className="text-2xl font-bold text-purple-600">
+                <p className="text-2xl font-bold text-electric-600">
                   {carbonData?.comparison?.reductionPotential ? '-' : '+'}
                   {Math.abs(carbonData?.comparison?.reductionPotential || 0)}%
                 </p>
                 <p className="text-xs text-gray-500">Carbon impact</p>
               </div>
-              <Target className="w-8 h-8 text-purple-600" />
+              <Target className="w-8 h-8 text-electric-600" />
             </div>
           </CardContent>
         </Card>
@@ -605,8 +605,8 @@ function ReportsTab({ carbonData, expenseData }: any) {
               <div className="font-medium">Receipts Complete</div>
               <div className="text-sm text-gray-600 dark:text-gray-300">100% documentation</div>
             </div>
-            <div className="text-center p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-              <Leaf className="w-8 h-8 text-purple-600 mx-auto mb-2" />
+            <div className="text-center p-4 bg-electric-50 dark:bg-electric-900/20 rounded-lg">
+              <Leaf className="w-8 h-8 text-electric-600 mx-auto mb-2" />
               <div className="font-medium">Sustainability Goals</div>
               <div className="text-sm text-gray-600 dark:text-gray-300">On track for carbon targets</div>
             </div>

--- a/client/src/components/ItineraryOptimizationModal.tsx
+++ b/client/src/components/ItineraryOptimizationModal.tsx
@@ -83,7 +83,7 @@ export function ItineraryOptimizationModal({
       <DialogContent className="max-w-4xl max-h-[80vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-purple-600" />
+            <Sparkles className="h-5 w-5 text-electric-600" />
             AI Itinerary Optimization
           </DialogTitle>
           <DialogDescription>
@@ -95,7 +95,7 @@ export function ItineraryOptimizationModal({
           {!optimizationResult ? (
             <div className="text-center py-8">
               <div className="mb-4">
-                <Sparkles className="h-12 w-12 text-purple-600 mx-auto mb-2" />
+                <Sparkles className="h-12 w-12 text-electric-600 mx-auto mb-2" />
                 <h3 className="text-lg font-semibold">Ready to Optimize</h3>
                 <p className="text-muted-foreground">
                   Analyze {activities.length} activities across {Math.ceil((new Date(trip.endDate).getTime() - new Date(trip.startDate).getTime()) / (1000 * 60 * 60 * 24))} days
@@ -105,7 +105,7 @@ export function ItineraryOptimizationModal({
               <Button
                 onClick={handleOptimize}
                 disabled={optimizeItinerary.isPending || activities.length === 0}
-                className="bg-purple-600 hover:bg-purple-700"
+                className="bg-electric-600 hover:bg-electric-700"
               >
                 {optimizeItinerary.isPending ? (
                   <>
@@ -182,7 +182,7 @@ export function ItineraryOptimizationModal({
                                 </div>
                               </div>
                               {(hasTimeChange || hasDayChange) && (
-                                <Badge variant="secondary" className="bg-purple-100 text-purple-700">
+                                <Badge variant="secondary" className="bg-electric-100 text-electric-700">
                                   Changes suggested
                                 </Badge>
                               )}

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -49,7 +49,7 @@ const notificationIcons = {
 const notificationColors = {
   trip_shared: 'text-blue-600',
   trip_update: 'text-green-600',
-  booking_confirmed: 'text-purple-600',
+  booking_confirmed: 'text-electric-600',
   payment_due: 'text-red-600',
   team_invite: 'text-orange-600',
   system: 'text-slate-600',

--- a/client/src/components/PredictiveInsights.tsx
+++ b/client/src/components/PredictiveInsights.tsx
@@ -414,12 +414,12 @@ function OptimizationInsights({ data }: { data: any }) {
         <Card>
           <CardHeader>
             <CardTitle className="text-lg flex items-center gap-2">
-              <TrendingUp className="w-5 h-5 text-purple-600" />
+              <TrendingUp className="w-5 h-5 text-electric-600" />
               Experience Score
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-purple-600">
+            <div className="text-2xl font-bold text-electric-600">
               {experienceOptimization?.satisfactionScore || 0}/10
             </div>
             <div className="text-sm text-gray-600 dark:text-gray-300">
@@ -457,8 +457,8 @@ function OptimizationInsights({ data }: { data: any }) {
           <CardContent>
             <div className="space-y-2">
               {experienceOptimization?.personalizedSuggestions?.map((suggestion: string, index: number) => (
-                <div key={index} className="flex items-start gap-2 p-2 bg-purple-50 dark:bg-purple-900/20 rounded">
-                  <Lightbulb className="w-4 h-4 text-purple-600 mt-0.5 flex-shrink-0" />
+                <div key={index} className="flex items-start gap-2 p-2 bg-electric-50 dark:bg-electric-900/20 rounded">
+                  <Lightbulb className="w-4 h-4 text-electric-600 mt-0.5 flex-shrink-0" />
                   <span className="text-sm">{suggestion}</span>
                 </div>
               ))}

--- a/client/src/components/ShareRedirectHandler.tsx
+++ b/client/src/components/ShareRedirectHandler.tsx
@@ -28,7 +28,7 @@ export default function ShareRedirectHandler() {
   // If it's an edit permission and we have trip data, don't render anything (redirect happening)
   if (permission === 'edit' && sharedTrip && (sharedTrip as any).id) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-electric-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600 dark:text-gray-400">Redirecting to edit mode...</p>

--- a/client/src/components/TravelMode.tsx
+++ b/client/src/components/TravelMode.tsx
@@ -332,7 +332,7 @@ export default function TravelMode({ tripId, activities, currentActivity }: Trav
         <Card>
           <CardHeader>
             <CardTitle className="text-lg flex items-center gap-2">
-              <MapPin className="w-5 h-5 text-purple-600" />
+              <MapPin className="w-5 h-5 text-electric-600" />
               Nearby Activities
             </CardTitle>
           </CardHeader>

--- a/client/src/components/cards/CardsList.tsx
+++ b/client/src/components/cards/CardsList.tsx
@@ -86,7 +86,7 @@ export function CardsList({ cards, onCardAction, isLoading }: CardsListProps) {
             <CardContent className="p-6">
               <div className="flex justify-between items-start mb-4">
                 <div className="flex items-center gap-3">
-                  <div className="h-10 w-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
+                  <div className="h-10 w-16 bg-gradient-to-r from-blue-500 to-electric-600 rounded-lg flex items-center justify-center">
                     <CreditCard className="h-5 w-5 text-white" />
                   </div>
                   <div>

--- a/client/src/components/optimization/OptimizationSummary.tsx
+++ b/client/src/components/optimization/OptimizationSummary.tsx
@@ -108,15 +108,15 @@ export function OptimizationSummary({ result, onApplyChanges, onReject, isLoadin
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-600 dark:text-gray-400">Carbon Reduction</p>
-                <p className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+                <p className="text-2xl font-bold text-electric-600 dark:text-electric-400">
                   {result.carbonReduction}kg
                 </p>
                 <p className="text-sm text-gray-500">
                   CO₂ emissions saved
                 </p>
               </div>
-              <div className="h-12 w-12 bg-purple-100 dark:bg-purple-900/20 rounded-lg flex items-center justify-center">
-                <TrendingUp className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+              <div className="h-12 w-12 bg-electric-100 dark:bg-electric-900/20 rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-electric-600 dark:text-electric-400" />
               </div>
             </div>
           </CardContent>

--- a/client/src/components/superadmin/DashboardMetrics.tsx
+++ b/client/src/components/superadmin/DashboardMetrics.tsx
@@ -51,7 +51,7 @@ export function DashboardMetrics({ data }: DashboardMetricsProps) {
       value: `$${totalRevenue.toLocaleString()}`,
       description: "Total billing volume",
       icon: DollarSign,
-      color: "text-purple-600"
+      color: "text-electric-600"
     }
   ];
 

--- a/client/src/components/superadmin/OrganizationsList.tsx
+++ b/client/src/components/superadmin/OrganizationsList.tsx
@@ -50,7 +50,7 @@ export function OrganizationsList({ organizations, onOrganizationSelect, isLoadi
   const getPlanColor = (plan: string) => {
     switch (plan) {
       case 'enterprise':
-        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-300';
+        return 'bg-electric-100 text-electric-800 dark:bg-electric-900/20 dark:text-electric-300';
       case 'team':
         return 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-300';
       case 'basic':

--- a/client/src/components/superadmin/SystemMetrics.tsx
+++ b/client/src/components/superadmin/SystemMetrics.tsx
@@ -127,8 +127,8 @@ export function SystemMetrics({ dashboardData, isLoading }: SystemMetricsProps) 
                   {dashboardData.activeSessions?.length || 0}
                 </p>
               </div>
-              <div className="h-12 w-12 bg-purple-100 dark:bg-purple-900/20 rounded-lg flex items-center justify-center">
-                <Activity className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+              <div className="h-12 w-12 bg-electric-100 dark:bg-electric-900/20 rounded-lg flex items-center justify-center">
+                <Activity className="h-6 w-6 text-electric-600 dark:text-electric-400" />
               </div>
             </div>
           </CardContent>

--- a/client/src/components/system/OptimizationSummary.tsx
+++ b/client/src/components/system/OptimizationSummary.tsx
@@ -73,7 +73,7 @@ export function OptimizationSummary({
         <Card>
           <CardContent className="p-6">
             <div className="flex items-center gap-2">
-              <TrendingUp className="h-5 w-5 text-purple-500" />
+              <TrendingUp className="h-5 w-5 text-electric-500" />
               <div>
                 <p className="text-2xl font-bold">{performanceImprovements.memoryUsageReduction}%</p>
                 <p className="text-sm text-muted-foreground">Memory Usage</p>

--- a/client/src/pages/AITripGenerator.tsx
+++ b/client/src/pages/AITripGenerator.tsx
@@ -53,7 +53,7 @@ export default function AITripGeneratorPage() {
                   <span className="text-white/80">Real-time pricing</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-white/80">Instant itineraries</span>
                 </div>
               </div>

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -160,7 +160,7 @@ export default function AdminDashboard() {
                     <span className="text-electric-100">System monitoring</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                    <div className="w-2 h-2 bg-electric-400 rounded-full" />
                     <span className="text-electric-100">Platform analytics</span>
                   </div>
                 </div>

--- a/client/src/pages/AdminRoles.tsx
+++ b/client/src/pages/AdminRoles.tsx
@@ -169,7 +169,7 @@ export default function AdminRoles() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-electric-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
         <div className="flex items-center justify-center h-64">
           <div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
         </div>
@@ -178,7 +178,7 @@ export default function AdminRoles() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-electric-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <motion.div

--- a/client/src/pages/AdminSecurity.tsx
+++ b/client/src/pages/AdminSecurity.tsx
@@ -171,7 +171,7 @@ export default function AdminSecurity() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-electric-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <motion.div

--- a/client/src/pages/AdminSystemMetrics.tsx
+++ b/client/src/pages/AdminSystemMetrics.tsx
@@ -314,7 +314,7 @@ export default function AdminSystemMetrics() {
                     {metrics?.performance.throughput.toFixed(1) || '0'} req/s
                   </p>
                 </div>
-                <TrendingUp className="h-8 w-8 text-purple-500" />
+                <TrendingUp className="h-8 w-8 text-electric-500" />
               </div>
             </CardContent>
           </AnimatedCard>

--- a/client/src/pages/AgencyDashboard.tsx
+++ b/client/src/pages/AgencyDashboard.tsx
@@ -111,7 +111,7 @@ export default function AgencyDashboard() {
                   <span className="text-white/80">Revenue tracking</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-white/80">Win rate analytics</span>
                 </div>
               </div>

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -108,7 +108,7 @@ export default function Analytics() {
                   <span className="text-white/80">Custom reports</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-white/80">Export capabilities</span>
                 </div>
               </div>

--- a/client/src/pages/Bookings.tsx
+++ b/client/src/pages/Bookings.tsx
@@ -115,7 +115,7 @@ export default function Bookings() {
                   <span className="text-white/80">Group coordination</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-white/80">Instant booking</span>
                 </div>
               </div>

--- a/client/src/pages/CorporateCards.tsx
+++ b/client/src/pages/CorporateCards.tsx
@@ -390,7 +390,7 @@ export default function CorporateCards() {
                   <span className="text-electric-100">Instant approvals</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-electric-100">Smart controls</span>
                 </div>
               </div>

--- a/client/src/pages/CorporateDashboard.tsx
+++ b/client/src/pages/CorporateDashboard.tsx
@@ -249,7 +249,7 @@ export default function CorporateDashboard() {
                     <span className="text-electric-100">Team collaboration</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                    <div className="w-2 h-2 bg-electric-400 rounded-full" />
                     <span className="text-electric-100">Smart analytics</span>
                   </div>
                 </div>
@@ -486,7 +486,7 @@ export default function CorporateDashboard() {
                     onClick={() => setSelectedCard(card)}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="w-10 h-6 bg-gradient-to-r from-blue-500 to-purple-600 rounded flex items-center justify-center">
+                      <div className="w-10 h-6 bg-gradient-to-r from-blue-500 to-electric-600 rounded flex items-center justify-center">
                         <CreditCard className="h-3 w-3 text-white" />
                       </div>
                       <div>

--- a/client/src/pages/EnterpriseDashboard.tsx
+++ b/client/src/pages/EnterpriseDashboard.tsx
@@ -126,7 +126,7 @@ export default function EnterpriseDashboard() {
                   <span className="text-white/80">Revenue analytics</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full" />
+                  <div className="w-2 h-2 bg-electric-400 rounded-full" />
                   <span className="text-white/80">Performance metrics</span>
                 </div>
               </div>
@@ -196,7 +196,7 @@ export default function EnterpriseDashboard() {
                   <p className="text-sm font-medium text-muted-foreground">Completion Rate</p>
                   <p className="text-2xl font-bold text-foreground">{displayStats?.completionRate || 0}%</p>
                 </div>
-                <Target className="w-8 h-8 text-purple-600" />
+                <Target className="w-8 h-8 text-electric-600" />
               </div>
             </CardContent>
           </Card>

--- a/client/src/pages/FlightSearch.tsx
+++ b/client/src/pages/FlightSearch.tsx
@@ -177,7 +177,7 @@ export default function FlightSearch() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-electric-50 to-electric-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
         <motion.div

--- a/client/src/pages/HelpCenter.tsx
+++ b/client/src/pages/HelpCenter.tsx
@@ -256,7 +256,7 @@ export default function HelpCenter() {
               <Card className="hover:shadow-lg transition-shadow cursor-pointer">
                 <CardHeader>
                   <div className="flex items-center justify-between">
-                    <Brain className="h-8 w-8 text-purple-600" />
+                    <Brain className="h-8 w-8 text-electric-600" />
                     <Badge variant="secondary">Intermediate</Badge>
                   </div>
                   <CardTitle>AI Trip Generator</CardTitle>
@@ -332,7 +332,7 @@ export default function HelpCenter() {
               <Card className="hover:shadow-lg transition-shadow cursor-pointer">
                 <CardHeader>
                   <div className="flex items-center justify-between">
-                    <Shield className="h-8 w-8 text-indigo-600" />
+                    <Shield className="h-8 w-8 text-electric-600" />
                     <Badge variant="secondary">Security</Badge>
                   </div>
                   <CardTitle>Security & Privacy</CardTitle>
@@ -390,7 +390,7 @@ export default function HelpCenter() {
                     </div>
 
                     <div className="flex items-center gap-3 p-3 rounded-lg border">
-                      <Phone className="h-5 w-5 text-purple-600" />
+                      <Phone className="h-5 w-5 text-electric-600" />
                       <div>
                         <div className="font-medium">Phone Support</div>
                         <div className="text-sm text-slate-600 dark:text-slate-400">

--- a/client/src/pages/OrganizationFunding.tsx
+++ b/client/src/pages/OrganizationFunding.tsx
@@ -193,7 +193,7 @@ export default function OrganizationFunding() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center">
         <div className="flex items-center space-x-2">
-          <Loader2 className="h-6 w-6 animate-spin text-violet-600" />
+          <Loader2 className="h-6 w-6 animate-spin text-electric-600" />
           <span className="text-slate-600 dark:text-slate-300">Loading funding status...</span>
         </div>
       </div>
@@ -210,7 +210,7 @@ export default function OrganizationFunding() {
         >
           {/* Header */}
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-violet-600 to-indigo-600 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-electric-600 to-electric-600 bg-clip-text text-transparent">
               Organization Funding
             </h1>
             <p className="text-slate-600 dark:text-slate-300">
@@ -219,10 +219,10 @@ export default function OrganizationFunding() {
           </div>
 
           {/* Status Overview */}
-          <Card className="border-violet-200 dark:border-violet-800 shadow-lg">
+          <Card className="border-electric-200 dark:border-electric-800 shadow-lg">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Building2 className="h-5 w-5 text-violet-600" />
+                <Building2 className="h-5 w-5 text-electric-600" />
                 Funding Status Overview
               </CardTitle>
             </CardHeader>
@@ -500,7 +500,7 @@ export default function OrganizationFunding() {
                       <Button 
                         onClick={() => createAccountMutation.mutate()}
                         disabled={createAccountMutation.isPending}
-                        className="w-full bg-violet-600 hover:bg-violet-700"
+                        className="w-full bg-electric-600 hover:bg-electric-700"
                       >
                         {createAccountMutation.isPending ? (
                           <>
@@ -551,7 +551,7 @@ export default function OrganizationFunding() {
                       <Button 
                         onClick={() => onboardingMutation.mutate()}
                         disabled={onboardingMutation.isPending}
-                        className="w-full bg-violet-600 hover:bg-violet-700"
+                        className="w-full bg-electric-600 hover:bg-electric-700"
                       >
                         {onboardingMutation.isPending ? (
                           <>
@@ -714,7 +714,7 @@ export default function OrganizationFunding() {
                       <Button 
                         onClick={() => setupFundingMutation.mutate(fundingSource)}
                         disabled={setupFundingMutation.isPending}
-                        className="w-full bg-violet-600 hover:bg-violet-700"
+                        className="w-full bg-electric-600 hover:bg-electric-700"
                       >
                         {setupFundingMutation.isPending ? (
                           <>

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -28,7 +28,7 @@ const pricingTiers = [
     period: '/month',
     description: 'Everything in Basic plus professional features',
     icon: Crown,
-    color: 'from-purple-500 to-purple-600',
+    color: 'from-electric-500 to-electric-600',
     features: [
       'Everything in Basic',
       'White label branding',
@@ -85,7 +85,7 @@ export default function Pricing() {
           animate={{ opacity: 1, y: 0 }}
           className="text-center mb-16"
         >
-          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-6">
+          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-electric-600 to-blue-600 bg-clip-text text-transparent mb-6">
             Choose Your Plan
           </h1>
           <p className="text-xl text-slate-600 dark:text-slate-300 max-w-3xl mx-auto">
@@ -107,7 +107,7 @@ export default function Pricing() {
               >
                 {tier.recommended && (
                   <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 z-10">
-                    <Badge className="bg-gradient-to-r from-purple-500 to-blue-500 text-white border-0 px-4 py-1">
+                    <Badge className="bg-gradient-to-r from-electric-500 to-blue-500 text-white border-0 px-4 py-1">
                       Most Popular
                     </Badge>
                   </div>
@@ -115,7 +115,7 @@ export default function Pricing() {
                 
                 <Card className={`h-full relative overflow-hidden ${
                   tier.recommended 
-                    ? 'border-purple-200 shadow-xl ring-2 ring-purple-100 dark:border-purple-700 dark:ring-purple-800' 
+                    ? 'border-electric-200 shadow-xl ring-2 ring-electric-100 dark:border-electric-700 dark:ring-electric-800' 
                     : 'border-slate-200 dark:border-slate-700'
                 }`}>
                   <div className={`absolute top-0 left-0 right-0 h-1 bg-gradient-to-r ${tier.color}`} />
@@ -157,7 +157,7 @@ export default function Pricing() {
                     <Button 
                       className={`w-full mt-6 ${
                         tier.recommended
-                          ? 'bg-gradient-to-r from-purple-500 to-blue-500 hover:from-purple-600 hover:to-blue-600'
+                          ? 'bg-gradient-to-r from-electric-500 to-blue-500 hover:from-electric-600 hover:to-blue-600'
                           : 'bg-slate-900 hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200'
                       }`}
                     >
@@ -176,7 +176,7 @@ export default function Pricing() {
           transition={{ delay: 0.5 }}
           className="mt-16 text-center"
         >
-          <Card className="max-w-4xl mx-auto bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 border-purple-200 dark:border-purple-700">
+          <Card className="max-w-4xl mx-auto bg-gradient-to-r from-electric-50 to-blue-50 dark:from-electric-900/20 dark:to-blue-900/20 border-electric-200 dark:border-electric-700">
             <CardContent className="p-8">
               <h3 className="text-2xl font-bold mb-4 text-slate-900 dark:text-slate-100">
                 Tier Inheritance Benefits
@@ -196,7 +196,7 @@ export default function Pricing() {
                   </p>
                 </div>
                 <div className="text-center">
-                  <div className="w-12 h-12 mx-auto rounded-lg bg-gradient-to-r from-purple-500 to-purple-600 flex items-center justify-center mb-3">
+                  <div className="w-12 h-12 mx-auto rounded-lg bg-gradient-to-r from-electric-500 to-electric-600 flex items-center justify-center mb-3">
                     <Crown className="w-6 h-6 text-white" />
                   </div>
                   <h4 className="font-semibold mb-2">Keep Everything</h4>

--- a/client/src/pages/ProposalCenter.tsx
+++ b/client/src/pages/ProposalCenter.tsx
@@ -180,7 +180,7 @@ export default function ProposalCenter() {
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg flex items-center gap-2">
-                  <Users className="h-5 w-5 text-purple-600" />
+                  <Users className="h-5 w-5 text-electric-600" />
                   Enterprise Ready
                 </CardTitle>
               </CardHeader>

--- a/client/src/pages/PublicProposal.tsx
+++ b/client/src/pages/PublicProposal.tsx
@@ -274,7 +274,7 @@ export default function PublicProposal({ proposalId }: PublicProposalViewProps) 
         <Card onMouseEnter={() => handleSectionView("itinerary")}>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Calendar className="w-5 h-5 text-purple-600" />
+              <Calendar className="w-5 h-5 text-electric-600" />
               Detailed Itinerary
             </CardTitle>
             <CardDescription>Day-by-day breakdown of your travel experience</CardDescription>

--- a/client/src/pages/SuperadminClean.tsx
+++ b/client/src/pages/SuperadminClean.tsx
@@ -112,7 +112,7 @@ export default function SuperadminClean() {
         {[
           { label: 'Organizations', value: organizations.length, color: 'from-blue-500 to-blue-600' },
           { label: 'Total Users', value: users.length, color: 'from-green-500 to-green-600' },
-          { label: 'Active Sessions', value: '23', color: 'from-purple-500 to-purple-600' },
+          { label: 'Active Sessions', value: '23', color: 'from-electric-500 to-electric-600' },
           { label: 'System Health', value: '99.9%', color: 'from-orange-500 to-orange-600' }
         ].map((metric, index) => (
           <motion.div

--- a/client/src/pages/SuperadminOrganizationDetail.tsx
+++ b/client/src/pages/SuperadminOrganizationDetail.tsx
@@ -421,7 +421,7 @@ export default function SuperadminOrganizationDetail() {
             { 
               label: 'Plan', 
               value: organization.plan, 
-              color: 'from-purple-500 to-purple-600',
+              color: 'from-electric-500 to-electric-600',
               icon: CreditCard,
               badge: organization.subscription_status || 'inactive'
             },

--- a/client/src/pages/WhiteLabelDomains.tsx
+++ b/client/src/pages/WhiteLabelDomains.tsx
@@ -135,7 +135,7 @@ export default function WhiteLabelDomains() {
                 <Card>
                   <CardContent className="pt-6">
                     <div className="flex items-center space-x-2">
-                      <ExternalLink className="h-5 w-5 text-purple-500" />
+                      <ExternalLink className="h-5 w-5 text-electric-500" />
                       <div>
                         <p className="text-sm font-medium">Active</p>
                         <p className="text-2xl font-bold">0</p>
@@ -160,7 +160,7 @@ export default function WhiteLabelDomains() {
             </CardHeader>
             <CardContent>
               {whiteLabelConfig?.isWhiteLabelActive ? (
-                <div className="p-6 border rounded-lg bg-gradient-to-r from-blue-50 to-purple-50">
+                <div className="p-6 border rounded-lg bg-gradient-to-r from-blue-50 to-electric-50">
                   <div 
                     className="text-2xl font-bold mb-2"
                     style={{ color: whiteLabelConfig.config.primaryColor }}


### PR DESCRIPTION
## Summary
- replace leftover purple/violet colors with electric violet palette
- keep gradients consistent with electric shades

## Testing
- `npm test` *(fails: TS errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685031a428c883239d3d4d17239aabf3