### PR TITLE
Frontend audit cleanup

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ export default function Dashboard() {
   const { user } = useAuth();
   const [isNewTripModalOpen, setIsNewTripModalOpen] = useState(false);
   const [, setLocation] = useLocation();
-  const isCorporate = useMemo(() => user?.roles.includes(UserRole.CORPORATE), [user]);
+  const isCorporate = useMemo(() => user?.role === UserRole.CORPORATE, [user]); // FIX: use single role property
 
   const { 
     data: tripsData, 

--- a/client/src/pages/FlightSearch.tsx
+++ b/client/src/pages/FlightSearch.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Calendar, CalendarDays } from "@/components/ui/calendar";
+import { Calendar } from "@/components/ui/calendar"; // FIX: remove unused CalendarDays
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { format } from "date-fns";
 import { useToast } from "@/hooks/use-toast";

--- a/client/src/pages/SuperadminFixed.tsx
+++ b/client/src/pages/SuperadminFixed.tsx
@@ -1,3 +1,4 @@
+// UNUSED - legacy superadmin page
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'wouter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';

--- a/client/src/pages/SuperadminSimple.tsx
+++ b/client/src/pages/SuperadminSimple.tsx
@@ -1,3 +1,4 @@
+// UNUSED - legacy superadmin page
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'wouter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -31,6 +31,7 @@
     "types": ["vite/client", "node"],
     "typeRoots": [
       "./node_modules/@types",
+      "../node_modules/@types",
       "./src/types"
     ]
   },

--- a/notes.md
+++ b/notes.md
@@ -73,3 +73,8 @@ This document contains technical notes, reasoning behind fixes, edge case handli
 
 ## TODOs for Follow-up
 <!-- To be populated during audit -->
+
+### Frontend audit notes
+- Adjusted `client/tsconfig.json` to include root `node_modules` for TypeScript checks.
+- Marked `SuperadminFixed.tsx` and `SuperadminSimple.tsx` as `// UNUSED` for potential deletion.
+- Fixed some minor type issues in `Dashboard` and `FlightSearch`.

--- a/plan.md
+++ b/plan.md
@@ -13,6 +13,10 @@
 
 ## 🔧 Fixes Applied
 <!-- Add fixes as they're implemented -->
+- Removed unused CalendarDays import in `FlightSearch`.
+- Fixed role check in `Dashboard` to use `user.role`.
+- Marked legacy `SuperadminFixed` and `SuperadminSimple` pages as unused.
+- Added root node type path in `client/tsconfig.json` for tsc.
 
 ## 🔮 Suggested Enhancements
 - [ ] Add sample orgs and proposals for demo [optional]
@@ -33,3 +37,10 @@ The following pages were identified as unused but represent important B2B functi
 4. **Testing** – verify the new routes render properly and navigation works when logged in.
 
 ## 🧠 See notes.md for full technical notes
+
+## Frontend Audit
+
+- [ ] Remove unused legacy superadmin pages.
+- [ ] Resolve remaining TypeScript errors in client.
+- [ ] Audit accessibility of all forms (labels, aria).
+- [ ] Deduplicate Tailwind styles in `index.css`.


### PR DESCRIPTION
## Summary
- mark legacy superadmin pages as unused
- adjust tsc `typeRoots`
- fix `Dashboard` corporate role check
- remove unused `CalendarDays` import
- update audit notes

## Testing
- `npm test` *(fails: Could not compile tests)*

------
https://chatgpt.com/codex/tasks/task_e_68503911a8f083238ebca69aec051696