### PR TITLE
Backend audit fixes

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -78,3 +78,4 @@ This document contains technical notes, reasoning behind fixes, edge case handli
 - Adjusted `client/tsconfig.json` to include root `node_modules` for TypeScript checks.
 - Marked `SuperadminFixed.tsx` and `SuperadminSimple.tsx` as `// UNUSED` for potential deletion.
 - Fixed some minor type issues in `Dashboard` and `FlightSearch`.
+- Updated JWT middleware logging and flagged raw SQL queries for review.

--- a/plan.md
+++ b/plan.md
@@ -17,6 +17,8 @@
 - Fixed role check in `Dashboard` to use `user.role`.
 - Marked legacy `SuperadminFixed` and `SuperadminSimple` pages as unused.
 - Added root node type path in `client/tsconfig.json` for tsc.
+- Fixed auth logger to use `payload.email` and marked unused rate limiter in `jwtAuth`.
+- Flagged raw SQL queries in `superadmin` routes for parameterization.
 
 ## 🔮 Suggested Enhancements
 - [ ] Add sample orgs and proposals for demo [optional]

--- a/server/middleware/jwtAuth.ts
+++ b/server/middleware/jwtAuth.ts
@@ -10,7 +10,7 @@ import { jwtService } from '../utils/jwtService';
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100 // limit each IP to 100 requests per windowMs
-});
+}); // UNUSED
 
 // Redis-based rate limiter
 const rateLimiter = new RateLimiterRedis({
@@ -76,7 +76,7 @@ export const validateJWT = async (req: Request, res: Response, next: NextFunctio
       } as User;
 
       // Log successful authentication
-      logger.info(`User ${decoded.email} authenticated successfully`, {
+      logger.info(`User ${payload.email} authenticated successfully`, {
         ip: req.ip,
         userAgent: req.headers['user-agent']
       });

--- a/server/routes/superadmin.ts
+++ b/server/routes/superadmin.ts
@@ -447,11 +447,11 @@ router.delete('/users/:id', requireSuperadminRole, async (req, res) => {
 router.get('/activity', requireSuperadminRole, async (req, res) => {
   try {
     // Use direct SQL to avoid schema mismatches
-    const activities = await db.execute(`
-      SELECT id, superadmin_user_id as admin_user_id, action, target_type as entity_type, 
+    const activities = await db.execute(` // TODO: parameterize query
+      SELECT id, superadmin_user_id as admin_user_id, action, target_type as entity_type,
              target_id as entity_id, details, risk_level, created_at
-      FROM superadmin_audit_logs 
-      ORDER BY created_at DESC 
+      FROM superadmin_audit_logs
+      ORDER BY created_at DESC
       LIMIT 100
     `);
 
@@ -964,7 +964,7 @@ router.get('/dashboard', requireSuperadminRole, async (req, res) => {
       `),
       
       // Activity logs
-      db.execute(`
+      db.execute(` // TODO: parameterize query
         SELECT id, superadmin_user_id as admin_user_id, action, target_type as entity_type, target_id as entity_id, details, risk_level, created_at
         FROM superadmin_audit_logs
         ORDER BY created_at DESC


### PR DESCRIPTION
## Summary
- mark unused `limiter` in jwt middleware
- fix logger reference to use `payload.email`
- flag raw SQL queries in superadmin routes
- update plan and notes with audit info

## Testing
- `npm test` *(fails: TS errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68503c329af483239d42a1d5ed3bbac4