### PR TITLE
Fix backend import paths

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -35,6 +35,7 @@ This document contains technical notes, reasoning behind fixes, edge case handli
 - Marking uncertain cases for manual review
 - Prioritizing type safety and consistent naming conventions
 - Refactoring duplicated logic into shared modules
+- Fixed several relative import paths in backend that pointed to wrong parent directories (e.g. auth routes, secureAuth middleware, JWT utilities).
 
 ## Feature Verification Notes
 

--- a/plan.md
+++ b/plan.md
@@ -19,6 +19,7 @@
 - Added root node type path in `client/tsconfig.json` for tsc.
 - Fixed auth logger to use `payload.email` and marked unused rate limiter in `jwtAuth`.
 - Flagged raw SQL queries in `superadmin` routes for parameterization.
+- Fixed backend import paths (`comprehensive-rate-limiting`, `secureJwt`, `jwt` utilities) to resolve module not found errors.
 
 ## 🔮 Suggested Enhancements
 - [ ] Add sample orgs and proposals for demo [optional]

--- a/server/middleware/secureAuth.ts
+++ b/server/middleware/secureAuth.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { verifyToken, TokenPayload, TokenType } from '../../utils/secureJwt';
+import { verifyToken, TokenPayload, TokenType } from '../utils/secureJwt';
 import { redis } from '../db/redis';
 import { logger } from '../utils/logger';
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/auth/dtos/auth.dto';
 
 // Import middleware
-import { authRateLimit } from '../../middleware/comprehensive-rate-limiting';
+import { authRateLimit } from '../middleware/comprehensive-rate-limiting';
 import { validateRequest } from '../src/auth/middleware/validation.middleware';
 
 export const createAuthRouter = (configService: ConfigService): Router => {

--- a/server/src/auth/controllers/auth.controller.ts
+++ b/server/src/auth/controllers/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   ResetPasswordDto
 } from '../dtos/auth.dto';
 import { rateLimiterMiddleware } from '../middleware/rate-limiter.middleware';
-import { isErrorWithMessage } from '../../utils/error-utils';
+import { isErrorWithMessage } from '../../../utils/error-utils';
 import { Logger } from '@nestjs/common';
 
 // Response type that excludes the refresh token when sending to client

--- a/server/src/auth/jwt/index.ts
+++ b/server/src/auth/jwt/index.ts
@@ -1,9 +1,9 @@
 import jwt, { type SignOptions } from 'jsonwebtoken';
 const { sign, verify, decode } = jwt;
 import { v4 as uuidv4 } from 'uuid';
-import { redis } from '../../utils/redis';
+import { redis } from '../../../utils/redis';
 // @ts-ignore - We know the logger exists
-import logger from '../../utils/logger';
+import logger from '../../../utils/logger';
 import {
   UserRole,
   TokenType,


### PR DESCRIPTION
## Summary
- correct middleware import in auth routes
- fix path to secureJwt in secureAuth middleware
- update jwt utility imports in auth service
- note import fixes in docs

## Testing
- `npx tsc -p server/tsconfig.json --noEmit --skipLibCheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68504d3790108323addc5a74e7368d66