### PR TITLE
Enhance AI routes with disaster and budget features

### DIFF
--- a/server/budgetForecast.ts
+++ b/server/budgetForecast.ts
@@ -1,0 +1,39 @@
+import { db } from './db';
+import { trips } from '../shared/schema';
+import { sql, and, eq } from 'drizzle-orm';
+
+export async function forecastBudget(
+  organizationId: string,
+  city: string,
+  startDate: string,
+  endDate: string,
+  travelers: number
+): Promise<{ dailyAverage: number; predictedTotal: number; dataPoints: number }> {
+  const pastTrips = await db
+    .select({
+      budget: trips.budget,
+      duration: sql<number>`EXTRACT(days FROM ${trips.endDate} - ${trips.startDate})`
+    })
+    .from(trips)
+    .where(and(eq(trips.organizationId, organizationId), eq(trips.city, city)))
+    .limit(20);
+
+  const dailyCosts = pastTrips
+    .filter(t => t.budget && t.duration && t.duration > 0)
+    .map(t => t.budget! / t.duration!);
+
+  const dailyAverage =
+    dailyCosts.length > 0
+      ? Math.round(dailyCosts.reduce((a, b) => a + b, 0) / dailyCosts.length)
+      : 15000; // default $150/day in cents
+
+  const durationDays = Math.max(
+    1,
+    Math.ceil((new Date(endDate).getTime() - new Date(startDate).getTime()) / (1000 * 60 * 60 * 24))
+  );
+
+  const predictedTotal = dailyAverage * durationDays * travelers;
+
+  return { dailyAverage, predictedTotal, dataPoints: dailyCosts.length };
+}
+

--- a/server/disasterMonitor.ts
+++ b/server/disasterMonitor.ts
@@ -1,0 +1,56 @@
+
+interface DisasterEvent {
+  id: string;
+  magnitude: number;
+  place: string;
+  time: string;
+  coordinates: [number, number];
+}
+
+/**
+ * Very small set of city to coordinate mappings for demo purposes.
+ * In production, this should be replaced with a real geocoding service.
+ */
+const cityMap: Record<string, { latitude: number; longitude: number }> = {
+  'San Francisco': { latitude: 37.7749, longitude: -122.4194 },
+  'New York': { latitude: 40.7128, longitude: -74.006 },
+  'Los Angeles': { latitude: 34.0522, longitude: -118.2437 },
+  London: { latitude: 51.5074, longitude: -0.1278 },
+  Paris: { latitude: 48.8566, longitude: 2.3522 },
+  Tokyo: { latitude: 35.6762, longitude: 139.6503 },
+  Berlin: { latitude: 52.52, longitude: 13.405 },
+};
+
+export async function fetchEarthquakeAlerts(
+  city: string,
+  startDate: string,
+  endDate: string,
+  radiusKm = 300
+): Promise<DisasterEvent[]> {
+  const coords = cityMap[city];
+  if (!coords) {
+    throw new Error('Unsupported city for disaster monitoring.');
+  }
+
+  const url =
+    `https://earthquake.usgs.gov/fdsnws/events/1/query?format=geojson&starttime=${startDate}` +
+    `&endtime=${endDate}&latitude=${coords.latitude}&longitude=${coords.longitude}` +
+    `&maxradiuskm=${radiusKm}&minmagnitude=4.5`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`USGS API error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as any;
+  if (!data.features) return [];
+
+  return data.features.map((f: any) => ({
+    id: f.id,
+    magnitude: f.properties.mag,
+    place: f.properties.place,
+    time: new Date(f.properties.time).toISOString(),
+    coordinates: [f.geometry.coordinates[1], f.geometry.coordinates[0]]
+  }));
+}
+

--- a/server/groupReconciler.ts
+++ b/server/groupReconciler.ts
@@ -1,0 +1,25 @@
+export interface TravelerPreference {
+  userId: string;
+  preferences: string[];
+}
+
+export interface ReconciledPreferences {
+  priorityList: string[];
+  conflicts: Array<{ preference: string; supporters: number }>;
+}
+
+export function reconcilePreferences(preferences: TravelerPreference[]): ReconciledPreferences {
+  const counts = new Map<string, number>();
+  for (const pref of preferences) {
+    for (const p of pref.preferences) {
+      counts.set(p, (counts.get(p) || 0) + 1);
+    }
+  }
+
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const priorityList = sorted.map(([p]) => p);
+  const conflicts = sorted.filter(([_, count]) => count < preferences.length).map(([p, count]) => ({ preference: p, supporters: count }));
+
+  return { priorityList, conflicts };
+}
+


### PR DESCRIPTION
## Summary
- add earthquake-based disaster monitor service
- implement historical budget forecasting service
- provide group preference reconciliation logic
- extend AI routes to expose disaster alerts, budget predictions, and preference reconciliation

## Testing
- `npm run check` *(fails: Cannot find name 'JwtPayload' etc.)*
- `npm test` *(fails: TypeScript errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68508df69b008323ba94beef1c510b76