### PR TITLE
Fix utils imports and typing

### DIFF
--- a/server/routes/activities.ts
+++ b/server/routes/activities.ts
@@ -1,21 +1,21 @@
 import { Router, type Response, type NextFunction, type RequestHandler, type Request } from 'express';
 import { ParamsDictionary } from 'express-serve-static-core';
-import { getAuthContext, requireAuth } from '../utils/authContext';
-import { logUserActivity } from '../utils/activityLogger';
+import { getAuthContext, requireAuth } from '../utils/authContext.js';
+import { logUserActivity } from '../utils/activityLogger.js';
 
 // Re-export types for backward compatibility
-export type { AuthUser, JWTUser } from '../utils/authContext';
+export type { AuthUser, JWTUser } from '../utils/authContext.js';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 
 // Import types and schemas
-import type { Activity, ActivityStatus, ActivityType } from '../types/activity';
-import { activitySchema, createActivitySchema, updateActivitySchema } from '../types/activity';
-import { User } from '../db/schema';
+import type { Activity, ActivityStatus, ActivityType } from '../types/activity.js';
+import { activitySchema, createActivitySchema, updateActivitySchema } from '../types/activity.js';
+import { User } from '../db/schema.js';
 
 // Import services
-import activityService from '../services/activity.service';
-import { validateOrganizationAccess } from '../middleware/organization';
+import activityService from '../services/activity.service.js';
+import { validateOrganizationAccess } from '../middleware/organization.js';
 
 // Define JWTUser interface for this file
 interface JWTUser {

--- a/server/routes/approvals.ts
+++ b/server/routes/approvals.ts
@@ -143,6 +143,7 @@ router.patch('/:requestId/decision', asyncHandler(async (req, res) => {
 
 // Create approval request
 router.post('/', asyncHandler(async (req, res) => {
+  try {
     if (!req.user?.organization_id) {
       return res.status(401).json({ error: "Organization membership required" });
     }
@@ -219,6 +220,7 @@ router.get('/rules', asyncHandler(async (req, res) => {
 
 // Create or update approval rule
 router.post('/rules', asyncHandler(async (req, res) => {
+  try {
     if (!req.user?.organization_id) {
       return res.status(401).json({ error: "Organization membership required" });
     }

--- a/server/test-app.ts
+++ b/server/test-app.ts
@@ -109,7 +109,7 @@ app.use(session({
 app.use('/api', apiRoutes);
 
 // Global error handling middleware
-app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+app.use(((err: any, req: Request, res: Response, next: NextFunction) => {
   console.error('Test app error:', err.message);
   
   if (res.headersSent) {
@@ -119,6 +119,6 @@ app.use((err: any, req: Request, res: Response, next: NextFunction) => {
   res.status(500).json({
     message: err.message || 'Internal server error'
   });
-});
+}) as express.ErrorRequestHandler);
 
 export { app };

--- a/server/utils/activityLogger.ts
+++ b/server/utils/activityLogger.ts
@@ -1,5 +1,5 @@
 import { db } from '../db/db.js';
-import { userActivityLogs } from '../db/schema';
+import { userActivityLogs } from '../db/schema.js';
 
 /**
  * Logs a user activity to the database.

--- a/server/utils/exporters.ts
+++ b/server/utils/exporters.ts
@@ -30,7 +30,7 @@ export function exportTripToICS(trip: any): string {
   }));
   const { error, value } = createEvents(events);
   if (error) throw error;
-  return value;
+  return value || "";
 }
 
 function parseDateTime(date: string, time?: string): number[] {

--- a/server/utils/organizationHelpers.redundant.ts
+++ b/server/utils/organizationHelpers.redundant.ts
@@ -5,9 +5,10 @@ import { AuthUser } from '../src/types/auth-user.js';
  * Gets the organization ID from the request user object
  */
 export function getOrganizationId(req: Request): string | undefined {
-  if (!req.user) return undefined;
-  
-  return (req.user as AuthUser).organization_id;
+  const user = (req as any).user as AuthUser | undefined;
+  if (!user) return undefined;
+
+  return user.organization_id;
 }
 
 /**

--- a/server/utils/redis.ts
+++ b/server/utils/redis.ts
@@ -1,4 +1,4 @@
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 
 // Create Redis client
 export const redisClient = new Redis({
@@ -8,7 +8,7 @@ export const redisClient = new Redis({
 });
 
 // Add error handling
-redisClient.on('error', (error) => {
+redisClient.on('error', (error: unknown) => {
   console.error('Redis error:', error);
 });
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "../vite.config.js";
 import { nanoid } from "nanoid";
 // __dirname is available in the compiled CommonJS output
 const currentDir = __dirname;
@@ -42,7 +42,7 @@ export async function setupVite(app: Express, server: Server) {
     appType: "custom",
   });
 
-  app.use(vite.middlewares);
+  app.use(vite.middlewares as any);
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 


### PR DESCRIPTION
## Summary
- patch utils to use `.js` paths
- return a string in exporters
- handle optional user in org helper
- update Redis import and typings
- tweak vite config import and middleware usage
- type test error handler

## Testing
- `npx tsc -b --pretty false > tsc.log`
- `tail -n 20 tsc.log`


------
https://chatgpt.com/codex/tasks/task_e_685570e030748323a59a228b33ed105a