### PR TITLE
Add ESLint rule for no-explicit-any

### DIFF
--- a/audit-report.md
+++ b/audit-report.md
@@ -783,7 +783,7 @@ The database uses PostgreSQL with Drizzle ORM for schema definition and query bu
 
 ### 1.2 Type Safety Enhancements (1-2 weeks)
 - [x] Enable TypeScript's `strict` mode
-- [ ] Add ESLint rules to prevent `any` usage
+- [x] Add ESLint rules to prevent `any` usage
 - [ ] Implement runtime type validation with Zod
 - [x] Add type checking to CI/CD pipeline
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,4 +10,9 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], languageOptions: { globals: globals.browser } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
 ]);


### PR DESCRIPTION
## Summary
- enforce `@typescript-eslint/no-explicit-any` in eslint.config.js
- mark ESLint rule work as complete in `audit-report.md`

## Testing
- `npx tsc -p server/tsconfig.json --noEmit` *(fails: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_685a14c312608323b2e2cd40ce4ee573