### PR TITLE
Add repository transaction support

### DIFF
--- a/audit-report.md
+++ b/audit-report.md
@@ -825,7 +825,7 @@ The database uses PostgreSQL with Drizzle ORM for schema definition and query bu
 
 ### 4.2 Repository Pattern (2 weeks)
 - [ ] Standardize repository interfaces
-- [ ] Add transaction support
+ - [x] Add transaction support
 - [ ] Implement proper error handling
 - [ ] Add query optimization
 

--- a/server/src/common/repositories/REPOSITORY_PATTERN.md
+++ b/server/src/common/repositories/REPOSITORY_PATTERN.md
@@ -213,6 +213,17 @@ export class BookingModule {}
 - **Modularity** - Repositories can be swapped out without affecting business logic
 - **Scalability** - New features can be added without modifying existing code
 
+### Transaction Support
+
+All repositories inherit a `withTransaction` helper from `BaseRepositoryImpl`. Use this method to group multiple operations in a single database transaction:
+
+```typescript
+await userRepository.withTransaction(async (tx) => {
+  await tx.insert(users).values(newUser);
+  await tx.insert(auditLogs).values(logEntry);
+});
+```
+
 ## Best Practices
 
 1. Always extend the base repository interface and implementation

--- a/server/src/common/repositories/base.repository.interface.ts
+++ b/server/src/common/repositories/base.repository.interface.ts
@@ -1,3 +1,6 @@
+import type { NodePgTransaction } from 'drizzle-orm/node-postgres';
+import type { TablesRelationalConfig } from 'drizzle-orm/relations';
+
 /**
  * Base repository interface defining common CRUD operations
  */
@@ -9,4 +12,11 @@ export interface BaseRepository<T, ID, CreateData, UpdateData> {
     delete(id: ID): Promise<boolean>;
     count(filter?: Partial<T>): Promise<number>;
     exists(id: ID): Promise<boolean>;
+    /**
+     * Execute multiple operations within a single database transaction.
+     *
+     * @param fn - Callback containing transactional operations using the
+     *   provided transaction instance.
+     */
+    withTransaction<R>(fn: (tx: NodePgTransaction<Record<string, unknown>, TablesRelationalConfig>) => Promise<R>): Promise<R>;
 }

--- a/server/src/common/repositories/base.repository.ts
+++ b/server/src/common/repositories/base.repository.ts
@@ -2,6 +2,8 @@ import { logger } from '../../../utils/logger.js';
 import type { BaseRepository } from './base.repository.interface.js';
 import { eq } from 'drizzle-orm';
 import { db } from '../../../db/db.js';
+import type { NodePgTransaction } from 'drizzle-orm/node-postgres';
+import type { TablesRelationalConfig } from 'drizzle-orm/relations';
 /**
  * Base repository implementation with common CRUD operations
  */
@@ -84,5 +86,9 @@ export abstract class BaseRepositoryImpl<T, ID, CreateData extends Record<string
     async exists(id: ID): Promise<boolean> {
         const entity = await this.findById(id);
         return entity !== null;
+    }
+
+    async withTransaction<R>(fn: (tx: NodePgTransaction<Record<string, unknown>, TablesRelationalConfig>) => Promise<R>): Promise<R> {
+        return db.transaction(fn);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `withTransaction` helper to `BaseRepository`
- document transaction usage in repository pattern doc
- check off transaction support in audit report

## Testing
- `pnpm check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685a18d65ee88323a348a8def1828baf