### PR TITLE
Fix TS errors in utils

### DIFF
--- a/client/src/pages/SequentialBookingFlights.tsx
+++ b/client/src/pages/SequentialBookingFlights.tsx
@@ -558,7 +558,9 @@ export default function SequentialBookingFlights() {
                         {flight.segments && flight.segments.length > 1 ? (
                     // Multi-segment flight with connections
                     <div className="space-y-2 text-sm">
-                            {(flight.segments || []).map((segment: FlightSegment, segmentIndex: number) => segment ? (<div key={segmentIndex} className="flex items-center gap-2">
+                            {(flight.segments || []).map((segment: FlightSegment, segmentIndex: number) =>
+                              segment ? (
+                                <div key={segmentIndex} className="flex items-center gap-2">
                                 <div className="flex-1 grid grid-cols-3 gap-4">
                                   <div>
                                     <p className="font-medium">{formatTime(segment.departure.at || segment.departure.time)}</p>
@@ -577,10 +579,13 @@ export default function SequentialBookingFlights() {
                                     <p className="text-muted-foreground">{getAirportCode(segment.arrival)}</p>
                                   </div>
                                 </div>
-                                {segmentIndex < flight.segments.length - 1 && (<div className="text-xs text-muted-foreground px-2 py-1 bg-muted rounded">
+                                {segmentIndex < flight.segments.length - 1 && (
+                                  <div className="text-xs text-muted-foreground px-2 py-1 bg-muted rounded">
                                     Connection
-                                  </div>)}
-                              </div>))}
+                                  </div>
+                                )}
+                              </div>
+                            ) : null)}
                             <div className="text-xs text-muted-foreground mt-2">
                               Total journey: {formatDuration(flight.duration)} • {flight.stops} stop{flight.stops !== 1 ? 's' : ''}
                             </div>

--- a/client/src/utils/logger.ts
+++ b/client/src/utils/logger.ts
@@ -5,10 +5,11 @@ interface LogContext {
     action?: string;
     component?: string;
     metadata?: Record<string, any>;
+    [key: string]: unknown;
 }
 class Logger {
-    private isDevelopment = process.env.NODE_ENV === 'development';
-    private isProduction = process.env.NODE_ENV === 'production';
+    private isDevelopment = process.env['NODE_ENV'] === 'development';
+    private isProduction = process.env['NODE_ENV'] === 'production';
     private formatMessage(level: LogLevel, message: string, context?: LogContext): string {
         const timestamp = new Date().toISOString();
         const contextStr = context ? ` | Context: ${JSON.stringify(context)}` : '';


### PR DESCRIPTION
## Summary
- fix nested map return logic in SequentialBookingFlights page
- allow flexible context fields in logger utility
- access NODE_ENV via index notation for type safety

## Testing
- `npx tsc -p client/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685cf71db4b88323915fb7b9495cc560