### PR TITLE
Fix server type imports

### DIFF
--- a/server/approvalEngine.ts
+++ b/server/approvalEngine.ts
@@ -1,6 +1,6 @@
 import prisma from './prisma';
 import { Prisma, ApprovalRequest, ApprovalRule, ApprovalLog, User, Organization, OrganizationMember, ApprovalStatus, ApprovalPriority, UserRole } from '@prisma/client';
-import type { ApprovalWorkflowData, ApprovalWorkflowConfig, ApprovalRuleConditions } from '../shared/src/types/approval/approval.types.js';
+import type { ApprovalWorkflowData, ApprovalWorkflowConfig, ApprovalRuleConditions } from '@shared/schema/types/approval/approval.types.js';
 
 // Helper type for a user with organization context and approver role
 type UserWithOrg = Omit<User, 'role'> & {

--- a/server/businessTripGenerator.ts
+++ b/server/businessTripGenerator.ts
@@ -86,7 +86,7 @@ import type {
   Meal,
   Transportation,
   TravelPolicy
-} from '@shared/src/types/trip/business-trip.types.js';
+} from '@shared/schema/types/trip/business-trip.types.js';
 
 // Extended FlightSegment with price information and baggage allowance
 interface FlightSegmentWithPrice extends Omit<SharedFlightSegment, 'id'> {

--- a/server/calendar.ts
+++ b/server/calendar.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from './express-augmentations.js';
 // Import types directly from the shared directory
-import type { Activity, Trip } from '../shared/src/schema.js';
+import type { Activity, Trip } from '@shared/schema';
 // Generate iCal format content for calendar export
 export function generateICalContent(trip: Trip, activities: Activity[]): string {
     const events = activities.map(activity => {

--- a/server/calendarSync.ts
+++ b/server/calendarSync.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import type { Activity, Trip } from '../../shared/src/schema'; // Updated path to match project structure
+import type { Activity, Trip } from '@shared/schema';
 import crypto from "crypto";
 
 // Define response types for calendar sync operations

--- a/server/db-connection.ts
+++ b/server/db-connection.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import * as schema from "../shared/src/schema.js";
+import * as schema from "@shared/schema";
 import config from './config.js';
 import { logger } from './utils/logger.js';
 // Check if Supabase credentials are provided

--- a/server/duffelProvider.ts
+++ b/server/duffelProvider.ts
@@ -6,7 +6,7 @@ import type {
   DuffelBookingResponse, 
   FlightSearchResult, 
   HotelSearchResult
-} from '../shared/src/types/trip/business-trip.types.js';
+} from '@shared/schema/types/trip/business-trip.types.js';
 
 interface HotelBookingParams {
   searchResultId: string;

--- a/server/jest-esm.config.cjs
+++ b/server/jest-esm.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
   
   // Module name mapper for path aliases
   moduleNameMapper: {
-    '^@shared/(.*)\.js$': '<rootDir>/../shared/src/$1',
+    '^@shared/schema/(.*)\.js$': '<rootDir>/../shared/src/$1',
     '^@server/(.*)\.js$': '<rootDir>/src/$1',
     '^@db/(.*)\.js$': '<rootDir>/db/$1',
   },

--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
-    '^@shared/(.*)\.js$': '<rootDir>/../shared/src/$1',
+    '^@shared/schema/(.*)\.js$': '<rootDir>/../shared/src/$1',
     '^@server/(.*)\.js$': '<rootDir>/src/$1',
     '^@db/(.*)\.js$': '<rootDir>/db/$1',
   },

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config.InitialOptions = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^@server/(.*)\.js$': '<rootDir>/src/$1',
-    '^@shared/(.*)\.js$': '<rootDir>/../shared/src/$1',
+    '^@shared/schema/(.*)\.js$': '<rootDir>/../shared/src/$1',
     '^(\.{1,2}/.*)\.js$': '$1',
   },
   transform: {

--- a/server/proposalGenerator.ts
+++ b/server/proposalGenerator.ts
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import type { Trip, Activity } from '../shared/src/schema';
+import type { Trip, Activity } from '@shared/schema';
 export interface ProposalData {
     trip: Trip;
     activities: Activity[];

--- a/server/routes/activities.ts
+++ b/server/routes/activities.ts
@@ -11,7 +11,7 @@ import type {
   ActivityStatus,
   ActivityType,
   Activity as SharedActivityType
-} from '@shared/src/types/activity/index.js';
+} from '@shared/schema/types/activity/index.js';
 
 /**
  * Extended Activity type that includes server-specific fields
@@ -36,7 +36,7 @@ export type Activity = SharedActivityType & {
   updatedAt?: Date;
 };
 
-import { activityFormSchema } from '@shared/src/types/activity/index.js';
+import { activityFormSchema } from '@shared/schema/types/activity/index.js';
 import activityService from '../services/activity.service.js';
 import { validateOrganizationAccess } from '../middleware/organization.js';
 

--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -3,7 +3,7 @@ import type { ParamsDictionary, Query as ParsedQs } from 'express-serve-static-c
 import { authenticate as validateJWT } from '../middleware/secureAuth.js';
 import { injectOrganizationContext, validateOrganizationAccess } from '../middleware/organizationContext.js';
 import { z } from 'zod';
-import type { User } from '@shared/src/types/auth';
+import type { User } from '@shared/schema/types/auth';
 import OpenAI from 'openai';
 import { db } from '../db/db.js';
 import { trips, activities } from '../db/schema.js';

--- a/server/smartOptimizer.ts
+++ b/server/smartOptimizer.ts
@@ -1,6 +1,6 @@
 import { getOpenAIClient, OPENAI_MODEL } from "./services/openaiClient.js";
 import { detectTripConflicts } from "./services/conflictDetector.js";
-import type { Activity, OptimizedSchedule } from '../shared/interfaces.js';
+import type { Activity, OptimizedSchedule } from '@shared/schema/types/trip/TripActivityTypes.js';
 interface ConflictDetection {
     type: 'time_overlap' | 'location_conflict' | 'capacity_issue' | 'schedule_gap';
     severity: 'low' | 'medium' | 'high';

--- a/server/src/auth/controllers/__tests__/auth.controller.spec.ts
+++ b/server/src/auth/controllers/__tests__/auth.controller.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from '../auth.controller.js';
 import { AuthService } from '../../services/auth.service.js';
-import { LoginDto, RegisterDto, AuthResponse } from '@shared/src/types/auth/jwt/jwt.ts';
-import { UserRole } from '@shared/src/types/auth/permissions.js';
+import { LoginDto, RegisterDto, AuthResponse } from '@shared/schema/types/auth/jwt/jwt.js';
+import { UserRole } from '@shared/schema/types/auth/permissions.js';
 import type { Response } from 'express';
 
 describe('AuthController', () => {

--- a/server/src/auth/controllers/auth.controller.ts
+++ b/server/src/auth/controllers/auth.controller.ts
@@ -31,14 +31,14 @@ import type { ApiSuccessResponse } from '../../common/utils/response-formatter.u
 import { isErrorWithMessage } from '../../utils/error-utils.js';
 
 import type { IAuthService } from '../interfaces/auth.service.interface.js';
-import type { AuthenticatedRequest } from '@shared/types/auth/custom-request.js';
+import type { AuthenticatedRequest } from '@shared/schema/types/auth/custom-request.js';
 import { 
   LoginDto, 
   RequestPasswordResetDto, 
   ResetPasswordDto,
   AuthResponse as SharedAuthResponse,
   AuthTokens
-} from '@shared/types/auth/index.js';
+} from '@shared/schema/types/auth/index.js';
 import type { User as PrismaUser } from '@prisma/client';
 import type { User as SharedUser } from '@shared/schema/types/user';
 

--- a/server/src/auth/controllers/prisma-auth.controller.ts
+++ b/server/src/auth/controllers/prisma-auth.controller.ts
@@ -42,10 +42,10 @@ import {
   ResetPasswordDto, 
   ChangePasswordDto,
   AuthTokens
-} from '@shared/types/auth/index.js';
+} from '@shared/schema/types/auth/index.js';
 import { UserRole } from '@prisma/client';
 // Import shared auth types
-import { AuthErrorCode } from '@shared/types/auth/auth.js';
+import { AuthErrorCode } from '@shared/schema/types/auth/auth.js';
 import type { AuthenticatedRequest } from '@shared/schema/types/auth/custom-request';
 
 // Import services

--- a/server/src/auth/interfaces/auth.service.interface.ts
+++ b/server/src/auth/interfaces/auth.service.interface.ts
@@ -7,7 +7,7 @@ import type {
   UserResponse,
   AuthResponse,
   UserRole
-} from '@shared/types';
+} from '@shared/schema/types/auth/index.js';
 
 export interface IAuthService {
   /**

--- a/server/src/auth/jwt/index.ts
+++ b/server/src/auth/jwt/index.ts
@@ -33,10 +33,10 @@ import type {
   EmailVerificationTokenPayload,
   TokenType,
   TokenVerificationResult as JwtTokenVerificationResult
-} from '../../../../shared/src/types/auth/jwt.js';
+} from '@shared/schema/types/auth/jwt.js';
 
 // Import UserRole and getPermissionsForRole
-import { UserRole, getPermissionsForRole } from '../../../../shared/src/types/auth/permissions.js';
+import { UserRole, getPermissionsForRole } from '@shared/schema/types/auth/permissions.js';
 
 // Import constants
 import {

--- a/server/src/auth/jwt/types.ts
+++ b/server/src/auth/jwt/types.ts
@@ -6,8 +6,8 @@ import type {
   EmailVerificationTokenPayload,
   TokenType,
   TokenVerificationResult as SharedTokenVerificationResult
-} from '../../../../shared/src/types/auth/jwt.js';
-import type { UserRole } from '../../../../shared/src/types/auth/permissions.js';
+} from '@shared/schema/types/auth/jwt.js';
+import type { UserRole } from '@shared/schema/types/auth/permissions.js';
 
 // Re-export shared types
 export type { 

--- a/server/src/auth/jwt/utils.ts
+++ b/server/src/auth/jwt/utils.ts
@@ -3,7 +3,7 @@ import { randomBytes, createHash } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import { redisClient as redis } from '../../../utils/redis.js';
 import { logger } from '../../../utils/logger.js';
-import type { JwtPayload } from '../../../../shared/src/types/auth/jwt.js';
+import type { JwtPayload } from '@shared/schema/types/auth/jwt.js';
 import type { 
   JwtConfig,
   ExtendedAuthTokens,

--- a/server/src/auth/middleware/index.ts
+++ b/server/src/auth/middleware/index.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../jwt/index.js';
-import type { TokenVerificationResult } from '../../../../shared/src/types/auth/jwt.js';
-import type { AuthUser } from '../../../../shared/src/types/auth/index.js';
+import type { TokenVerificationResult } from '@shared/schema/types/auth/jwt.js';
+import type { AuthUser } from '@shared/schema/types/auth/index.js';
 import { logger } from '../../utils/logger.js';
 import { redisClient as redis } from '../../utils/redis.js';
 // Extend Express Request type

--- a/server/src/auth/middleware/prisma-jwt.middleware.ts
+++ b/server/src/auth/middleware/prisma-jwt.middleware.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { prismaAuthService } from '../services/prisma-auth.service.js';
 import { PrismaUserRepository } from '../../common/database/index.js';
-import { AuthErrorCode, AuthErrorException } from '@shared/types/auth/auth.js';
+import { AuthErrorCode, AuthErrorException } from '@shared/schema/types/auth/auth.js';
 import { logger } from '../../../utils/logger.js';
 import type { UserRole as PrismaUserRole } from '@prisma/client';
 import { hasRole as checkRole, hasPermission as checkPermission } from '../../types/auth-user.js';

--- a/server/src/auth/services/__tests__/auth.service.spec.ts
+++ b/server/src/auth/services/__tests__/auth.service.spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth.service.js';
 import { UserRepository } from '../../../common/repositories/user/user.repository.interface.js';
 import { RefreshTokenRepository } from '../../interfaces/refresh-token.repository.interface.js';
-import { UserRole } from '@shared/src/types/auth/permissions.js';
-import { LoginDto, RegisterDto } from '@shared/src/types/auth/dto/index.js';
+import { UserRole } from '@shared/schema/types/auth/permissions.js';
+import { LoginDto, RegisterDto } from '@shared/schema/types/auth/dto/index.js';
 
 describe('AuthService', () => {
   let service: AuthService;

--- a/server/src/auth/services/auth.service.ts
+++ b/server/src/auth/services/auth.service.ts
@@ -30,11 +30,11 @@ import type {
   AuthTokens,
   AccessTokenPayload,
   RefreshTokenPayload
-} from '@shared/types/auth/index.js';
+} from '@shared/schema/types/auth/index.js';
 import type { 
   User as SharedUser, 
   UserRole as SharedUserRole 
-} from '@shared/types/user/index.js';
+} from '@shared/schema/types/user/index.js';
 
 // Helper to create a slug from a string
 const slugify = (str: string) => str.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]+/g, '');

--- a/server/src/common/repositories/booking/booking.repository.interface.ts
+++ b/server/src/common/repositories/booking/booking.repository.interface.ts
@@ -3,7 +3,7 @@ import type {
   BookingStatus, 
   BookingType, 
   AnyBooking
-} from '@shared/types/booking/index.ts';
+} from '@shared/schema/types/booking/index.js';
 import type { BookingSearchParams } from '@shared/schema/types/booking';
 import type { BaseRepository } from '../base.repository.interface.js';
 

--- a/server/src/common/repositories/prisma/user.prisma.repository.ts
+++ b/server/src/common/repositories/prisma/user.prisma.repository.ts
@@ -1,6 +1,6 @@
 import { PrismaClient, User as PrismaUser, UserRole as PrismaUserRole } from '@prisma/client';
 import { UserRepository, UserListParams } from '../user/user.repository.interface.js';
-import { User, UserProfile, UserSettings, UserStats, UserActivity } from '@shared/types/auth/user.js';
+import { User, UserProfile, UserSettings, UserStats, UserActivity } from '@shared/schema/types/auth/user.js';
 import { UserRole } from '@shared/schema/types/auth/permissions';
 import { hash, compare } from 'bcrypt';
 

--- a/server/src/common/repositories/prisma/user.repository.ts
+++ b/server/src/common/repositories/prisma/user.repository.ts
@@ -1,8 +1,8 @@
 import { prisma } from '@db';
 import type { User as PrismaUser } from '@prisma/client';
 import type { UserRepository } from '../user.repository.interface';
-import type { UserResponse } from '@shared/src/types/auth/dto/response';
-import { UserRole } from '@shared/src/types/auth/permissions';
+import type { UserResponse } from '@shared/schema/types/auth/dto/response';
+import { UserRole } from '@shared/schema/types/auth/permissions';
 import { logger } from '../../../utils/logger.js';
 
 export class PrismaUserRepository implements UserRepository {

--- a/server/src/common/utils/auth-utils.ts
+++ b/server/src/common/utils/auth-utils.ts
@@ -1,4 +1,4 @@
-import { UserRole } from '../../../shared/src/types/auth/user.js';
+import { UserRole } from '@shared/schema/types/auth/user.js';
 
 /**
  * Check if a user has any of the specified roles

--- a/server/src/core/middleware/tenant.middleware.ts
+++ b/server/src/core/middleware/tenant.middleware.ts
@@ -1,6 +1,6 @@
 import { Injectable, NestMiddleware, ForbiddenException } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
-import { JwtPayload } from '../../shared/src/types/auth/jwt';
+import { JwtPayload } from '@shared/schema/types/auth/jwt';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/server/src/express-augmentations.d.ts
+++ b/server/src/express-augmentations.d.ts
@@ -1,4 +1,4 @@
-import type { AuthUser } from '@shared/src/types/auth/user.js';
+import type { AuthUser } from '@shared/schema/types/auth/user.js';
 
 declare global {
   namespace Express {

--- a/server/src/lib/types/mappers.ts
+++ b/server/src/lib/types/mappers.ts
@@ -1,5 +1,5 @@
 import type { Booking as DbBooking } from '../../db/schema/index.js';
-import type { BaseBooking, ServerBooking, AnyBooking } from '@shared/types/booking/index.js';
+import type { BaseBooking, ServerBooking, AnyBooking } from '@shared/schema/types/booking/index.js';
 /**
  * Maps a database booking to a server booking
  */

--- a/server/src/middleware/authenticate.ts
+++ b/server/src/middleware/authenticate.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../auth/jwt/index.js';
-import type { AccessTokenPayload } from '@shared/src/types/auth/jwt.js';
+import type { AccessTokenPayload } from '@shared/schema/types/auth/jwt.js';
 
 
 export async function authenticate(req: Request, res: Response, next: NextFunction): Promise<Response | void> {

--- a/server/src/trips/controllers/trip.controller.ts
+++ b/server/src/trips/controllers/trip.controller.ts
@@ -31,7 +31,7 @@ import {
 import { BaseController } from '../../common/controllers/base.controller.js';
 import type { TripService } from '../interfaces/trip.service.interface.js';
 import type { Trip, PaginationOptions } from '../interfaces/trip.interface.js';
-import type { AuthUser } from '@shared/types/auth/user.js';
+import type { AuthUser } from '@shared/schema/types/auth/user.js';
 import { isAdminOrManager } from '@server/common/utils/auth-utils.js';
 
 // Response DTOs for Swagger documentation

--- a/server/src/trips/interfaces/trip.interface.ts
+++ b/server/src/trips/interfaces/trip.interface.ts
@@ -1,5 +1,5 @@
 import { Trip as PrismaTrip } from '@prisma/client';
-import { User } from '../../../shared/src/types/auth';
+import { User } from '@shared/schema/types/auth';
 
 export interface Trip extends Omit<PrismaTrip, 'createdAt' | 'updatedAt'> {
   id: string;

--- a/server/src/trips/interfaces/trip.service.interface.ts
+++ b/server/src/trips/interfaces/trip.service.interface.ts
@@ -1,4 +1,4 @@
-import type { AuthUser } from '@shared/types/auth/user.js';
+import type { AuthUser } from '@shared/schema/types/auth/user.js';
 import type { 
   Trip, 
   CreateTripDto, 

--- a/server/src/types/express-types.d.ts
+++ b/server/src/types/express-types.d.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request as ExpressRequest } from 'express';
-import type { JwtPayload, UserRole, Permission } from '@shared/types';
+import type { JwtPayload, UserRole, Permission } from '@shared/schema/types';
 
 declare global {
   namespace Express {

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import type { AuthUser as SharedAuthUser, UserRole as SharedUserRole } from '../../../shared/src/types/auth/index.js';
+import type { AuthUser as SharedAuthUser, UserRole as SharedUserRole } from '@shared/schema/types/auth/index.js';
 
 // This file extends the Express Request type to include our custom properties
 

--- a/server/src/types/secure-request.ts
+++ b/server/src/types/secure-request.ts
@@ -1,6 +1,6 @@
 import type { Request as ExpressRequest, Response, NextFunction, RequestHandler } from 'express';
 import type { AuthUser } from './auth-user.js';
-import type { UserRole } from '../../../shared/src/types/user/index.js';
+import type { UserRole } from '@shared/schema/types/user/index.js';
 
 // Re-export AuthUser for convenience
 export type { AuthUser };

--- a/server/test/common/repositories/activity/activity.repository.spec.ts
+++ b/server/test/common/repositories/activity/activity.repository.spec.ts
@@ -3,10 +3,10 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import { eq, and, inArray, sql, type SQL, asc } from 'drizzle-orm';
 import { activities } from '../../../../db/schema/index.js';
 import { ActivityRepositoryImpl } from '../../../../src/common/repositories/activity/activity.repository.js';
-import type { 
-  ActivityStatus, 
-  ActivityType 
-} from '@shared/src/types/activity/index.js';
+import type {
+  ActivityStatus,
+  ActivityType
+} from '@shared/schema/types/activity/index.js';
 import type { Activity, NewActivity } from '@db/schema/activities/activities.js';
 
 // Define mock activity data for testing

--- a/server/test/mocks/mock-user.ts
+++ b/server/test/mocks/mock-user.ts
@@ -1,4 +1,4 @@
-import type { AuthUser, UserRole } from '../../../shared/src/types/auth/index.js';
+import type { AuthUser, UserRole } from '@shared/schema/types/auth/index.js';
 
 // Create a complete mock user that satisfies both AuthUser and Express.User
 export const mockUser: AuthUser & {

--- a/server/transformers/activity.transformer.ts
+++ b/server/transformers/activity.transformer.ts
@@ -1,4 +1,4 @@
-import { Activity } from '../../shared/types/activity';
+import { Activity } from '@shared/schema/types/activity';
 
 type ActivityInput = Omit<Activity, 'id' | 'createdAt' | 'updatedAt'>;
 

--- a/server/types/activity.ts
+++ b/server/types/activity.ts
@@ -6,7 +6,7 @@ export {
   type ActivityStatus,
   type ActivityType,
   type Activity,
-} from '@shared/types/activity';
+} from '@shared/schema/types/activity';
 export const activitySchema = z.object({
     id: z.string().uuid(),
     title: z.string().min(1, 'Title is required'),

--- a/server/types/custom-request.d.ts
+++ b/server/types/custom-request.d.ts
@@ -1,6 +1,6 @@
 import { Request as ExpressRequest } from '../../express-augmentations';
-import type { AuthUser } from '@shared/src/types/auth/user.js';
-import type { JwtPayload } from '@shared/src/types/auth/jwt.js';
+import type { AuthUser } from '@shared/schema/types/auth/user.js';
+import type { JwtPayload } from '@shared/schema/types/auth/jwt.js';
 
 declare module 'express-serve-static-core' {
   interface Request {

--- a/server/types/express-request.d.ts
+++ b/server/types/express-request.d.ts
@@ -1,5 +1,5 @@
-import type { AuthUser } from '@shared/src/types/auth/user.js';
-import type { JwtPayload } from '@shared/src/types/auth/jwt.js';
+import type { AuthUser } from '@shared/schema/types/auth/user.js';
+import type { JwtPayload } from '@shared/schema/types/auth/jwt.js';
 
 declare global {
   namespace Express {

--- a/server/types/express/index.d.ts
+++ b/server/types/express/index.d.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from '../../express-augmentations';
-import type { JwtPayload } from '@shared/src/types/auth';
-import type { User } from '@shared/src/types/auth';
+import type { JwtPayload } from '@shared/schema/types/auth';
+import type { User } from '@shared/schema/types/auth';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { ParsedQs } from 'qs';
 

--- a/server/types/jwt.d.ts
+++ b/server/types/jwt.d.ts
@@ -6,7 +6,7 @@ import type {
   User,
   TokenPayload,
   UserRole
-} from '@shared/src/types/auth';
+} from '@shared/schema/types/auth';
 
 export type { TokenType, TokenPayload, UserRole };
 

--- a/server/types/user.ts
+++ b/server/types/user.ts
@@ -2,5 +2,5 @@
 // Re-export them here for backwards compatibility so existing imports continue
 // to work while keeping a single source of truth for the structures.
 
-export type { User } from '@shared/src/types/auth/user';
-export type { JwtPayload } from '@shared/src/types/auth/jwt';
+export type { User } from '@shared/schema/types/auth/user';
+export type { JwtPayload } from '@shared/schema/types/auth/jwt';

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -3,7 +3,7 @@ import { randomBytes, createHash } from 'crypto';
 import { SALT_ROUNDS } from '../config/constants.js';
 import { logger } from './logger.js';
 import { users } from '../db/schema.js';
-import type { User } from '../../shared/src/schema';
+import type { User } from '@shared/schema';
 import { eq, and, sql } from 'drizzle-orm';
 import type { InferSelectModel } from 'drizzle-orm';
 import { dbService } from '../services/database.service.js';

--- a/server/utils/request.ts
+++ b/server/utils/request.ts
@@ -1,8 +1,8 @@
 import type { Response, NextFunction } from 'express';
-import { UserRole } from '@shared/types/user/index.js';
-import type { AuthenticatedRequest } from '@shared/src/types/auth/custom-request.js';
+import { UserRole } from '@shared/schema/types/user/index.js';
+import type { AuthenticatedRequest } from '@shared/schema/types/auth/custom-request.js';
 // Re-export the types for convenience
-export type { AuthenticatedRequest } from '@shared/src/types/auth/custom-request.js';
+export type { AuthenticatedRequest } from '@shared/schema/types/auth/custom-request.js';
 /**
  * Middleware to extend the Request object with custom methods
  */

--- a/server/utils/response.ts
+++ b/server/utils/response.ts
@@ -1,5 +1,5 @@
 import type { Response, Request, NextFunction } from 'express';
-import type { ApiResponse } from '@shared/types/api/index.js';
+import type { ApiResponse } from '@shared/schema/types/api/index.js';
 
 /**
  * Response utility for sending standardized API responses


### PR DESCRIPTION
## Summary
- use `@shared/schema` paths for shared type imports across server
- update Jest config mappings for new alias
- replace direct relative imports to shared module

## Testing
- `pnpm install`
- `pnpm --filter ./server test` *(fails: Invalid regular expression)*
- `pnpm --filter ./server run build` *(fails: TS1005)*

------
https://chatgpt.com/codex/tasks/task_e_68622e954e8c8323a4c43e79dba08d9e