### PR TITLE
Fix shared type imports in client

### DIFF
--- a/client/src/components/CollaborationPresence.tsx
+++ b/client/src/components/CollaborationPresence.tsx
@@ -1,7 +1,7 @@
-import type { SharedCollaboratorType } from '@shared/types/SharedCollaboratorType';
-import type { CollaborationPresenceProps, RecentActivityItem } from '@shared/types/collaboration/CollaborationTypes';
+import type { SharedCollaboratorType } from '@shared/schema/types/SharedCollaboratorType';
+import type { CollaborationPresenceProps, RecentActivityItem } from '@shared/schema/types/collaboration/CollaborationTypes';
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import type { ActivityData } from '@shared/types/activity/ActivityTypes';
+import type { ActivityData } from '@shared/schema/types/activity/ActivityTypes';
 import { ActivityAction } from '@shared/constants/ActivityActions.js';
 import { useRealTimeCollaboration } from '@/hooks/useRealTimeCollaboration';
 import { ACTIVITY_ACTIONS } from '@shared/constants/ActivityActions.js';

--- a/client/src/components/CorporateTripOptimizer.tsx
+++ b/client/src/components/CorporateTripOptimizer.tsx
@@ -1,4 +1,4 @@
-import { SharedTripType, SharedConflictFlagsType } from '@shared/types/trip';
+import { SharedTripType, SharedConflictFlagsType } from '@shared/schema/types/trip';
 import { useState } from 'react';
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';

--- a/client/src/components/RoleBasedRedirect.tsx
+++ b/client/src/components/RoleBasedRedirect.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useLocation } from 'wouter';
 import { useAuth } from '@/contexts/auth/useAuth';
 import { userService } from '@/services/api/userService';
-import { UserRole } from '@shared/types/auth/permissions';
+import { UserRole } from '@shared/schema/types/auth/permissions';
 // Super admin role types for type safety
 const SUPER_ADMIN_ROLES: UserRole[] = [
     UserRole.SUPER_ADMIN

--- a/client/src/components/booking/steps/FlightCard.tsx
+++ b/client/src/components/booking/steps/FlightCard.tsx
@@ -1,7 +1,7 @@
 import { format, differenceInMinutes, parseISO } from 'date-fns';
 import { Plane, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Flight, FlightSegment } from '@shared/types/flight';
+import { Flight, FlightSegment } from '@shared/schema/types/flight';
 
 interface FlightCardProps {
   flight: Flight;

--- a/client/src/components/booking/steps/FlightList.tsx
+++ b/client/src/components/booking/steps/FlightList.tsx
@@ -1,4 +1,4 @@
-import { Flight } from '@shared/types/flight';
+import { Flight } from '@shared/schema/types/flight';
 import { FlightCard } from './FlightCard';
 
 interface FlightListProps {

--- a/client/src/components/booking/steps/FlightSearchForm.tsx
+++ b/client/src/components/booking/steps/FlightSearchForm.tsx
@@ -9,7 +9,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { FlightSearchParams } from '@shared/types/flight';
+import { FlightSearchParams } from '@shared/schema/types/flight';
 import { MOCK_AIRPORTS, CABIN_CLASSES } from '@/utils/mockFlights';
 
 interface FlightSearchFormProps {

--- a/client/src/components/booking/steps/FlightSelectionStep.tsx
+++ b/client/src/components/booking/steps/FlightSelectionStep.tsx
@@ -5,8 +5,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ArrowLeft, Plane, ArrowRight } from 'lucide-react';
 import { FlightSearchForm } from './FlightSearchForm';
 import { FlightList } from './FlightList';
-import { Flight } from '@shared/types/flight';
-import { FlightSearchParams } from '@shared/types/flight';
+import { Flight } from '@shared/schema/types/flight';
+import { FlightSearchParams } from '@shared/schema/types/flight';
 import { flightService } from '@/services/api/flightService';
 import { BookingFormData } from '../types';
 

--- a/client/src/components/navigation/MainNavigation.tsx
+++ b/client/src/components/navigation/MainNavigation.tsx
@@ -4,7 +4,7 @@ import { MenuIcon, XIcon, BarChartIcon, CheckIcon, FileTextIcon, HomeIcon } from
 import { MobileMenu } from './MobileMenu';
 import { DesktopNavigation } from './DesktopNavigation';
 import type { NavigationItem, User } from './types';
-import type { Notification as AppNotification } from '@shared/types/notification';
+import type { Notification as AppNotification } from '@shared/schema/types/notification';
 interface MainNavigationProps {
     isAuthenticated: boolean;
     user: User | null;

--- a/client/src/components/navigation/NotificationsMenu.tsx
+++ b/client/src/components/navigation/NotificationsMenu.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { BellIcon } from '../icons';
 import type { NotificationsMenuProps } from './types';
-import type { Notification as AppNotification } from '@shared/types/notification';
+import type { Notification as AppNotification } from '@shared/schema/types/notification';
 
 // Helper function to safely cast notifications to AppNotification[]
 const getSafeNotifications = (notifications: unknown[]): AppNotification[] => {

--- a/client/src/components/routes/ProtectedRoute.tsx
+++ b/client/src/components/routes/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/state/contexts/AuthContext';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { UserRole } from '@shared/types/auth/UserRole';
+import { UserRole } from '@shared/schema/types/auth/UserRole';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;

--- a/client/src/components/routes/RouteRenderer.tsx
+++ b/client/src/components/routes/RouteRenderer.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useEffect } from 'react';
 import { Route, Routes, useLocation, matchPath } from 'react-router-dom';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import ErrorBoundary from '@/components/ErrorBoundary';
-import { UserRole } from '@shared/types/auth/user/index';
+import { UserRole } from '@shared/schema/types/auth/user/index';
 import { ProtectedRoute } from './ProtectedRoute';
 
 /**

--- a/client/src/contexts/auth/NewAuthContext.tsx
+++ b/client/src/contexts/auth/NewAuthContext.tsx
@@ -5,7 +5,7 @@ import { authService } from '@/services/authService';
 import { TokenManager } from '@/utils/tokenManager';
 import { SessionLockout } from '@/utils/sessionLockout';
 import { AuthUser, AuthError, AuthTokens, Permission, LoginDto, RegisterDto } from '@shared/schema/types/auth';
-import type { JwtPayload } from '@shared/types/auth/jwt';
+import type { JwtPayload } from '@shared/schema/types/auth/jwt';
 
 type UserResponse = AuthUser;
 

--- a/client/src/hooks/useRealTimeCollaboration.tsx
+++ b/client/src/hooks/useRealTimeCollaboration.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useLocation } from 'wouter';
-import type { WebSocketMessage } from '@shared/types/WebSocketMessageTypes';
-import type { CollaboratorPresence } from '@shared/types/CollaboratorPresence';
-import type { UseRealTimeCollaborationProps, ActivityData } from '@shared/types/activity/ActivityTypes';
+import type { WebSocketMessage } from '@shared/schema/types/WebSocketMessageTypes';
+import type { CollaboratorPresence } from '@shared/schema/types/CollaboratorPresence';
+import type { UseRealTimeCollaborationProps, ActivityData } from '@shared/schema/types/activity/ActivityTypes';
 import { ACTIVITY_ACTIONS } from '@shared/constants/ActivityActions.js';
 // Import base message types
 import { WS_MESSAGE_TYPES as BASE_WS_MESSAGE_TYPES } from '@shared/schema/constants/WebSocketMessageTypes.js';

--- a/client/src/hooks/useTrips.ts
+++ b/client/src/hooks/useTrips.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@shared/schema/api';
 import { API_ENDPOINTS } from '@/lib/constants';
 import { useAuth } from '@/contexts/auth/useAuth';
-import type { CreateTripDTO, UpdateTripDTO, TripQueryParams } from '@shared/types/trip/trip.dto';
+import type { CreateTripDTO, UpdateTripDTO, TripQueryParams } from '@shared/schema/types/trip/trip.dto';
 
 import type { SharedTripType } from '@shared/schema/types/trip/SharedTripType';
 

--- a/client/src/pages/SuperadminSimple.tsx
+++ b/client/src/pages/SuperadminSimple.tsx
@@ -11,7 +11,7 @@ import { apiRequest } from '@/lib/queryClient';
 import type { Organization } from '@shared/schema/types/organization';
 import type { User } from '@shared/schema/types/user';
 import type { Session } from '@shared/schema/types/session';
-import type { Job } from '@shared/types/job';
+import type { Job } from '@shared/schema/types/job';
 import type { LogEntry } from '@shared/schema/types/log';
 import type { Event } from '@shared/schema/types/event';
 import type { Flag } from '@shared/schema/types/flag';

--- a/client/src/services/api/utils/error.ts
+++ b/client/src/services/api/utils/error.ts
@@ -1,6 +1,6 @@
 import SharedErrorType from '@/types/SharedErrorType';
 import type { AxiosError } from 'axios';
-import type { RequestConfig, ApiErrorResponse } from '@shared/types/api';
+import type { RequestConfig, ApiErrorResponse } from '@shared/schema/types/api';
 
 /**
  * Custom error class for API errors

--- a/client/src/services/api/utils/request.ts
+++ b/client/src/services/api/utils/request.ts
@@ -1,5 +1,5 @@
 import type { AxiosResponse } from 'axios';
-import type { RequestConfig, ApiResponse } from '@shared/types/api';
+import type { RequestConfig, ApiResponse } from '@shared/schema/types/api';
 
 // Request cache entry
 interface RequestCacheEntry<T = any> {

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,6 +1,6 @@
 // Re-export types from shared location
 // This file is maintained for backward compatibility
-// New code should import directly from '@shared/types/user'
+// New code should import directly from '@shared/schema/types/user'
 
 export {
   type User,
@@ -14,10 +14,10 @@ export {
   createUserSchema,
   isUser,
   isUserRole
-} from '@shared/types/user';
+} from '@shared/schema/types/user';
 
 // Note: The following types are kept for backward compatibility
-// but should be considered deprecated. Use the ones from @shared/types/user instead
+// but should be considered deprecated. Use the ones from @shared/schema/types/user instead
 
 declare module '@shared/schema/types/user' {
   export interface User {


### PR DESCRIPTION
## Summary
- use `@shared/schema/types/*` imports throughout the client
- update comments to reference the correct shared alias

## Testing
- `pnpm check` *(fails: cannot find modules and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862802033ac8323a59211b3626a9038