### PR TITLE
Ensure Supabase env vars build DB url

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -51,8 +51,19 @@ function getSessionSecret(): string {
 }
 
 // Database configuration
+function getDatabaseUrl(): string | undefined {
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL;
+  }
+  if (process.env.SUPABASE_URL && process.env.SUPABASE_DB_PASSWORD) {
+    const supabaseUrl = new URL(process.env.SUPABASE_URL);
+    return `postgresql://postgres.${supabaseUrl.hostname.split('.')[0]}:${process.env.SUPABASE_DB_PASSWORD}@${supabaseUrl.hostname}:5432/postgres`;
+  }
+  return undefined;
+}
+
 export const DB_CONFIG = {
-  url: process.env.DATABASE_URL,
+  url: getDatabaseUrl(),
   connectionPoolSize: parseInt(process.env.DB_POOL_SIZE || '10', 10)
 };
 
@@ -99,7 +110,7 @@ export function validateConfig() {
   const env = process.env.NODE_ENV || 'development';
   
   const requiredVars = [
-    { name: 'DATABASE_URL', value: DB_CONFIG.url },
+    { name: 'DATABASE_URL or SUPABASE_URL/SUPABASE_DB_PASSWORD', value: DB_CONFIG.url },
     { name: 'VITE_MAPBOX_TOKEN', value: SERVICES_CONFIG.mapbox.token }
   ];
 
@@ -148,3 +159,5 @@ export default {
   jwt: JWT_CONFIG,
   validate: validateConfig
 };
+
+export { getDatabaseUrl };

--- a/server/db-connection.ts
+++ b/server/db-connection.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import * as schema from "./db/schema";
-import config from './config';
+import config, { getDatabaseUrl } from './config';
 import { logger } from './utils/logger';
 
 // Debug environment variables
@@ -47,11 +47,11 @@ export async function initializeDatabase(): Promise<DatabaseConnection> {
   if (!hasValidSupabaseUrl || !hasValidServiceKey || !hasValidDbPassword) {
     throw new Error('Missing required database credentials');
   }
-  // Get database URL from environment variables
-  const databaseUrl = process.env.DATABASE_URL;
+  // Get database URL from environment or Supabase credentials
+  const databaseUrl = getDatabaseUrl();
   
   if (!databaseUrl) {
-    throw new Error('DATABASE_URL environment variable is not set');
+    throw new Error('Database connection information is not set');
   }
 
   // Parse the database URL to extract connection details
@@ -78,7 +78,7 @@ export async function initializeDatabase(): Promise<DatabaseConnection> {
       ssl: 'enabled'
     });
   } catch (error) {
-    throw new Error(`Invalid DATABASE_URL: ${error.message}`);
+    throw new Error(`Invalid database URL: ${error.message}`);
   }
 
   try {

--- a/server/db/db.ts
+++ b/server/db/db.ts
@@ -1,5 +1,6 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+import { getDatabaseUrl } from '../config';
 import * as schema from './schema';
 import * as invoiceSchema from './invoiceSchema';
 import * as proposalSchema from './proposalSchema';
@@ -7,7 +8,7 @@ import * as superadminSchema from './superadminSchema';
 
 // Create a connection pool
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: getDatabaseUrl(),
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -3,6 +3,7 @@ import postgres from 'postgres';
 import { logger } from '../utils/logger';
 import * as schema from './schema';
 import * as tripSchema from './tripSchema';
+import { getDatabaseUrl } from '../config';
 
 // Combine all schemas
 const allSchemas = { ...schema, ...tripSchema };
@@ -13,10 +14,10 @@ let client: postgres.Sql | null = null;
 
 const connectDatabase = async (): Promise<void> => {
   try {
-    const connectionString = process.env.DATABASE_URL;
+    const connectionString = getDatabaseUrl();
     
     if (!connectionString) {
-      throw new Error('DATABASE_URL environment variable is required');
+      throw new Error('Database connection information is required');
     }
 
     // Create postgres client

--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -1,5 +1,6 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+import { getDatabaseUrl } from '../config';
 import * as schema from './schema';
 import * as invoiceSchema from './invoiceSchema';
 import * as proposalSchema from './proposalSchema';
@@ -7,7 +8,7 @@ import * as superadminSchema from './superadminSchema';
 
 // Create a connection pool
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: getDatabaseUrl(),
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 

--- a/server/test-app.ts
+++ b/server/test-app.ts
@@ -3,6 +3,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";
 import apiRoutes from "./routes/index";
+import { getDatabaseUrl } from "./config";
 
 // Security middleware imports
 import { preventSQLInjection, configureCORS } from "./middleware/secureAuth";
@@ -42,7 +43,7 @@ const app = express();
 // Initialize PostgreSQL session store
 const PgSession = connectPgSimple(session);
 const sessionStore = new PgSession({
-  conString: process.env.DATABASE_URL,
+  conString: getDatabaseUrl(),
   tableName: 'session',
   createTableIfMissing: true
 });


### PR DESCRIPTION
## Summary
- derive `DATABASE_URL` from Supabase credentials if not explicitly set
- use new helper in server DB connection utilities and tests

## Testing
- `pnpm test` *(fails: Module 'supertest' issues and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ea5639b548323a2d03c5eef3ff0cb