### PR TITLE
Refactor server imports to use drizzle-shim

### DIFF
--- a/server/db/proposalSchema.ts
+++ b/server/db/proposalSchema.ts
@@ -1,5 +1,5 @@
 import { pgTable, uuid, text, timestamp, integer, jsonb, pgEnum, index } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
+import { sql } from '../src/utils/drizzle-shim';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { users, organizations, trips } from './schema';

--- a/server/db/schema.js
+++ b/server/db/schema.js
@@ -1,5 +1,5 @@
 import { pgTable, uuid, text, timestamp, boolean, integer, jsonb, pgEnum, index } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
+import { sql } from '../src/utils/drizzle-shim';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { auditLogs as auditLogsTableDefinition } from "./auditLog"; // Assuming auditLog.ts is in the same directory

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,5 +1,5 @@
 import { pgTable, uuid, text, timestamp, boolean, integer, jsonb, pgEnum, index, type AnyPgColumn } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm/sql';
+import { sql } from '../src/utils/drizzle-shim';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 

--- a/server/scripts/test-payment-flow.ts
+++ b/server/scripts/test-payment-flow.ts
@@ -2,7 +2,7 @@
 
 import { db } from '../db/db';
 import { invoices } from '../db/invoiceSchema';
-import { eq } from 'drizzle-orm';
+import { eq } from '../src/utils/drizzle-shim';
 import type { Invoice, InvoiceItem } from '../types/invoice';
 import dotenv from 'dotenv';
 import { stripe } from '../stripe';

--- a/server/scripts/train-models.ts
+++ b/server/scripts/train-models.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import fs from 'fs/promises';
 import { db } from '../db/db';
 import { trips, activities, expenses } from '../db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql } from '../src/utils/drizzle-shim';
 import { GaussianNB } from 'ml-naivebayes';
 import MLR from 'ml-regression-multivariate-linear';
 

--- a/server/src/db/schema.js
+++ b/server/src/db/schema.js
@@ -1,5 +1,5 @@
 import { pgTable, uuid, text, timestamp, boolean, integer, jsonb, pgEnum, index } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
+import { sql } from '../utils/drizzle-shim';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { auditLogs as auditLogsTableDefinition } from "./auditLog"; // Assuming auditLog.ts is in the same directory

--- a/server/src/middleware/organizationContext.ts
+++ b/server/src/middleware/organizationContext.ts
@@ -294,7 +294,7 @@ export const resolveDomainOrganization = async (
     // Import database connection
     const { db } = await import('../db.js');
     const { customDomains } = await import('../db/schema');
-    const { eq } = await import('drizzle-orm');
+    const { eq } = await import('../utils/drizzle-shim.js');
 
     // Look up organization by custom domain
     const [domainConfig] = await db

--- a/server/src/permissions.ts
+++ b/server/src/permissions.ts
@@ -144,7 +144,7 @@ export const DEPARTMENT_PERMISSIONS = {
 export async function getUserPermissionsByRole(userId: number, role: string, organizationId?: number): Promise<any> {
   const { db } = await import('./db.js');
   const { users, organizations } = await import('./db/schema.js');
-  const { eq } = await import('drizzle-orm');
+  const { eq } = await import('../utils/drizzle-shim.js');
 
   try {
     // Get user's actual role and organization status

--- a/server/src/services/global-scalability.ts
+++ b/server/src/services/global-scalability.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 import { db } from '../db-connection';
 import { organizations } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { eq } from '../utils/drizzle-shim';
 
 // Types for better type safety
 interface RegionConfig {

--- a/server/src/services/voiceInterface.ts
+++ b/server/src/services/voiceInterface.ts
@@ -713,7 +713,7 @@ Format as JSON with arrays for restaurants, activities, and hotels. Include only
       // Import database connection
       const { db } = await import('../db/db.js');
       const { trips } = await import('../db/schema.js');
-      const { eq, desc } = await import('drizzle-orm');
+      const { eq, desc } = await import('../utils/drizzle-shim.js');
 
       if (tripId) {
         const trip = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);


### PR DESCRIPTION
## Summary
- use newly added drizzle-shim utilities across server scripts and modules
- update dynamic imports to load drizzle-shim instead of `drizzle-orm`

## Testing
- `pnpm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_688460ba9b0483239ff816be9d7727fb