### PR TITLE
Add base tRPC server setup

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,9 @@ import cookieParser from 'cookie-parser';
 import rateLimit from 'express-rate-limit';
 import { config } from 'dotenv';
 import { logger } from './utils/logger';
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import { appRouter } from './trpc/routers';
+import { createContext } from './trpc/context';
 
 // Import dynamic route setup
 import { setupRoutes } from './routes/index';
@@ -77,6 +80,12 @@ app.use(morgan('combined', {
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(cookieParser());
+
+// tRPC middleware
+app.use('/trpc', createExpressMiddleware({
+  router: appRouter,
+  createContext,
+}));
 
 // Health check endpoint
 app.get('/health', (_req, res) => {

--- a/server/src/trpc/context.ts
+++ b/server/src/trpc/context.ts
@@ -1,0 +1,10 @@
+import type { inferAsyncReturnType } from '@trpc/server';
+import { initTRPC } from '@trpc/server';
+import type { Request, Response } from 'express';
+
+export async function createContext({ req, res }: { req: Request; res: Response }) {
+  return { req, res };
+}
+export type Context = inferAsyncReturnType<typeof createContext>;
+
+export const t = initTRPC.context<Context>().create();

--- a/server/src/trpc/routers/health.ts
+++ b/server/src/trpc/routers/health.ts
@@ -1,0 +1,26 @@
+import { t } from '../context';
+import { z } from 'zod';
+
+const healthQuerySchema = z.object({
+  detailed: z.boolean().optional(),
+});
+
+export const healthRouter = t.router({
+  status: t.procedure
+    .input(healthQuerySchema)
+    .query(({ input }) => {
+      const detailed = input.detailed ?? false;
+      const response = {
+        status: 'healthy' as const,
+        timestamp: new Date().toISOString(),
+      };
+      if (detailed) {
+        return {
+          ...response,
+          environment: process.env.NODE_ENV || 'development',
+          version: '1.0.0',
+        };
+      }
+      return response;
+    }),
+});

--- a/server/src/trpc/routers/index.ts
+++ b/server/src/trpc/routers/index.ts
@@ -1,0 +1,8 @@
+import { t } from '../context';
+import { healthRouter } from './health';
+
+export const appRouter = t.router({
+  health: healthRouter,
+});
+
+export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary
- set up tRPC context and basic router
- expose tRPC health procedure
- mount tRPC middleware in the Express app

## Testing
- `pnpm install`
- `pnpm test` *(fails: numerous 404 errors in auth and trip tests)*

------
https://chatgpt.com/codex/tasks/task_e_688802c02e688323a799cf2ed15c3051