### PR TITLE
feat: filter templates with SQL

### DIFF
--- a/migrations/0004_marketplace_filter_indexes.sql
+++ b/migrations/0004_marketplace_filter_indexes.sql
@@ -1,0 +1,5 @@
+-- Indexes to support marketplace filtering
+CREATE INDEX IF NOT EXISTS idx_templates_price ON templates(price);
+CREATE INDEX IF NOT EXISTS idx_templates_duration ON templates(duration);
+CREATE INDEX IF NOT EXISTS idx_templates_tags_gin ON templates USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_templates_destinations_gin ON templates USING GIN (destinations);

--- a/server/routes/templates.ts
+++ b/server/routes/templates.ts
@@ -1,10 +1,10 @@
-import { Router } from 'express';
-import { storage } from '../storage';
-import { requireAuth } from '../middleware/jwtAuth';
-import { logger } from '../utils/logger';
-import { z } from 'zod';
-import { templateQualityService } from '../services/templateQualityService';
-import { sanitizeResponseDates } from '../utils/dateSanitizer';
+import { Router } from "express";
+import { storage } from "../storage";
+import { requireAuth } from "../middleware/jwtAuth";
+import { logger } from "../utils/logger";
+import { z } from "zod";
+import { templateQualityService } from "../services/templateQualityService";
+import { sanitizeResponseDates } from "../utils/dateSanitizer";
 
 const router = Router();
 
@@ -13,7 +13,7 @@ const createTemplateSchema = z.object({
   title: z.string().min(1).max(255),
   description: z.string().optional(),
   price: z.number().min(0).max(9999),
-  currency: z.string().default('USD'),
+  currency: z.string().default("USD"),
   cover_image: z.string().optional(),
   destinations: z.array(z.string()).default([]),
   duration: z.number().min(1).max(365).optional(),
@@ -22,22 +22,38 @@ const createTemplateSchema = z.object({
 });
 
 // GET /api/templates - Browse marketplace templates
-router.get('/', async (req, res) => {
+router.get("/", async (req, res) => {
   try {
-    const { search, tag, minPrice, maxPrice, duration, destination, sort = 'popular' } = req.query;
-    
-    // Get published templates with filters
-    let templates = await storage.getPublishedTemplates();
-    
+    const {
+      search,
+      tag,
+      minPrice,
+      maxPrice,
+      duration,
+      destination,
+      sort = "popular",
+    } = req.query;
+
+    // Get published templates with SQL filtering
+    let templates = await storage.searchTemplates({
+      search: search as string | undefined,
+      tag: tag as string | undefined,
+      minPrice: minPrice ? parseFloat(String(minPrice)) : undefined,
+      maxPrice: maxPrice ? parseFloat(String(maxPrice)) : undefined,
+      duration: duration ? parseInt(String(duration)) : undefined,
+      destination: destination as string | undefined,
+      sort: sort as string,
+    });
+
     // Transform templates to include activities array for frontend
-    templates = templates.map(template => {
-      const tripData = template.trip_data as any || {};
-      let activities = [];
-      
+    templates = templates.map((template) => {
+      const tripData = (template.trip_data as any) || {};
+      let activities: any[] = [];
+
       // Calculate a base date for the template (30 days from now)
       const baseDate = new Date();
       baseDate.setDate(baseDate.getDate() + 30);
-      
+
       // Extract activities from the days structure
       if (tripData.days && Array.isArray(tripData.days)) {
         tripData.days.forEach((day: any) => {
@@ -46,130 +62,63 @@ router.get('/', async (req, res) => {
             const dayDate = new Date(baseDate);
             const dayNumber = parseInt(day.day) || 1;
             dayDate.setDate(dayDate.getDate() + (dayNumber - 1));
-            
+
             // Check if date is valid before converting
-            const dateStr = !isNaN(dayDate.getTime()) 
-              ? dayDate.toISOString().split('T')[0] 
-              : new Date().toISOString().split('T')[0]; // Fallback to today
-            
+            const dateStr = !isNaN(dayDate.getTime())
+              ? dayDate.toISOString().split("T")[0]
+              : new Date().toISOString().split("T")[0]; // Fallback to today
+
             day.activities.forEach((activity: any) => {
               activities.push({
                 ...activity,
                 day: day.day,
                 dayTitle: day.title,
                 date: dateStr, // Add the date field for grouping
-                locationName: activity.location // Frontend expects locationName
+                locationName: activity.location, // Frontend expects locationName
               });
             });
           }
         });
       }
-      
+
       // Add the activities array to tripData
       tripData.activities = activities;
-      
+
       return {
         ...template,
         tripData, // Frontend expects camelCase
         salesCount: template.sales_count || 0, // Add camelCase versions
         reviewCount: template.review_count || 0,
         coverImage: template.cover_image,
-        viewCount: template.view_count || 0
+        viewCount: template.view_count || 0,
       };
     });
-    
-    // Apply filters
-    if (search) {
-      const searchLower = String(search).toLowerCase();
-      templates = templates.filter(t => 
-        t.title.toLowerCase().includes(searchLower) ||
-        t.description?.toLowerCase().includes(searchLower)
-      );
-    }
-    
-    if (tag) {
-      templates = templates.filter(t => 
-        (t.tags as string[])?.includes(String(tag))
-      );
-    }
-    
-    if (minPrice) {
-      templates = templates.filter(t => 
-        parseFloat(t.price || '0') >= parseFloat(String(minPrice))
-      );
-    }
-    
-    if (maxPrice) {
-      templates = templates.filter(t => 
-        parseFloat(t.price || '0') <= parseFloat(String(maxPrice))
-      );
-    }
-    
-    if (duration) {
-      templates = templates.filter(t => 
-        t.duration === parseInt(String(duration))
-      );
-    }
-    
-    if (destination) {
-      const destLower = String(destination).toLowerCase();
-      templates = templates.filter(t => 
-        (t.destinations as string[])?.some(d => 
-          d.toLowerCase().includes(destLower)
-        )
-      );
-    }
-    
-    // Apply sorting
-    switch (sort) {
-      case 'newest':
-        templates.sort((a, b) => {
-          const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
-          const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
-          return dateB - dateA;
-        });
-        break;
-      case 'price-low':
-        templates.sort((a, b) => 
-          parseFloat(a.price || '0') - parseFloat(b.price || '0')
-        );
-        break;
-      case 'price-high':
-        templates.sort((a, b) => 
-          parseFloat(b.price || '0') - parseFloat(a.price || '0')
-        );
-        break;
-      case 'popular':
-      default:
-        templates.sort((a, b) => (b.sales_count || 0) - (a.sales_count || 0));
-        break;
-    }
-    
+
     res.json(sanitizeResponseDates(templates));
   } catch (error) {
-    logger.error('Error fetching templates:', error);
-    res.status(500).json({ message: 'Failed to fetch templates' });
+    logger.error("Error fetching templates:", error);
+    res.status(500).json({ message: "Failed to fetch templates" });
   }
 });
 
 // GET /api/templates/my - Get user's own templates
-router.get('/my', requireAuth, async (req, res) => {
+router.get("/my", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templates = await storage.getTemplatesByUserId(userId);
     res.json(sanitizeResponseDates(templates));
   } catch (error) {
-    logger.error('Error fetching user templates:', error);
-    res.status(500).json({ message: 'Failed to fetch your templates' });
+    logger.error("Error fetching user templates:", error);
+    res.status(500).json({ message: "Failed to fetch your templates" });
   }
 });
 
 // GET /api/templates/purchased - Get user's purchased templates
-router.get('/purchased', requireAuth, async (req, res) => {
+router.get("/purchased", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const purchases = await storage.getUserPurchases(userId);
-    
+
     // Get full template details for each purchase
     const templates = await Promise.all(
       purchases.map(async (purchase) => {
@@ -179,49 +128,52 @@ router.get('/purchased', requireAuth, async (req, res) => {
           purchaseDate: purchase.purchased_at,
           purchaseId: purchase.id,
         };
-      })
+      }),
     );
-    
-    res.json(sanitizeResponseDates(templates.filter(t => t !== undefined)));
+
+    res.json(sanitizeResponseDates(templates.filter((t) => t !== undefined)));
   } catch (error) {
-    logger.error('Error fetching purchased templates:', error);
-    res.status(500).json({ message: 'Failed to fetch purchased templates' });
+    logger.error("Error fetching purchased templates:", error);
+    res.status(500).json({ message: "Failed to fetch purchased templates" });
   }
 });
 
 // GET /api/templates/:slug - Get single template by slug
-router.get('/:slug', async (req, res) => {
+router.get("/:slug", async (req, res) => {
   try {
     const { slug } = req.params;
     const template = await storage.getTemplateBySlug(slug);
-    
+
     if (!template) {
-      return res.status(404).json({ message: 'Template not found' });
+      return res.status(404).json({ message: "Template not found" });
     }
-    
+
     // Increment view count
     await storage.incrementTemplateViews(template.id);
-    
+
     // Check if user has purchased (if requireAuthd)
     let hasPurchased = false;
     if (req.user) {
-      hasPurchased = await storage.hasUserPurchasedTemplate(req.user.id, template.id);
+      hasPurchased = await storage.hasUserPurchasedTemplate(
+        req.user.id,
+        template.id,
+      );
     }
-    
+
     // Get creator profile
     const creatorProfile = await storage.getCreatorProfile(template.user_id);
-    
+
     // Get reviews
     const reviews = await storage.getTemplateReviews(template.id);
-    
+
     // Transform template data for frontend
-    const tripData = template.trip_data as any || {};
-    let activities = [];
-    
+    const tripData = (template.trip_data as any) || {};
+    let activities: any[] = [];
+
     // Calculate a base date for the template (30 days from now)
     const baseDate = new Date();
     baseDate.setDate(baseDate.getDate() + 30);
-    
+
     // Extract activities from the days structure
     if (tripData.days && Array.isArray(tripData.days)) {
       tripData.days.forEach((day: any) => {
@@ -230,213 +182,247 @@ router.get('/:slug', async (req, res) => {
           const dayDate = new Date(baseDate);
           const dayNumber = parseInt(day.day) || 1;
           dayDate.setDate(dayDate.getDate() + (dayNumber - 1));
-          
+
           // Check if date is valid before converting
-          const dateStr = !isNaN(dayDate.getTime()) 
-            ? dayDate.toISOString().split('T')[0] 
-            : new Date().toISOString().split('T')[0]; // Fallback to today
-          
+          const dateStr = !isNaN(dayDate.getTime())
+            ? dayDate.toISOString().split("T")[0]
+            : new Date().toISOString().split("T")[0]; // Fallback to today
+
           day.activities.forEach((activity: any) => {
             activities.push({
               ...activity,
               day: day.day,
               dayTitle: day.title,
               date: dateStr, // Add the date field for grouping
-              locationName: activity.location // Frontend expects locationName
+              locationName: activity.location, // Frontend expects locationName
             });
           });
         }
       });
     }
-    
+
     // Add the activities array to tripData
     tripData.activities = activities;
-    
-    res.json(sanitizeResponseDates({
-      ...template,
-      tripData, // Frontend expects camelCase
-      salesCount: template.sales_count || 0,
-      reviewCount: template.review_count || 0,
-      coverImage: template.cover_image,
-      viewCount: template.view_count || 0,
-      hasPurchased,
-      creator: creatorProfile,
-      reviews,
-    }));
+
+    res.json(
+      sanitizeResponseDates({
+        ...template,
+        tripData, // Frontend expects camelCase
+        salesCount: template.sales_count || 0,
+        reviewCount: template.review_count || 0,
+        coverImage: template.cover_image,
+        viewCount: template.view_count || 0,
+        hasPurchased,
+        creator: creatorProfile,
+        reviews,
+      }),
+    );
   } catch (error) {
-    logger.error('Error fetching template:', error);
-    res.status(500).json({ message: 'Failed to fetch template' });
+    logger.error("Error fetching template:", error);
+    res.status(500).json({ message: "Failed to fetch template" });
   }
 });
 
 // POST /api/templates - Create new template
-router.post('/', requireAuth, async (req, res) => {
+router.post("/", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const validatedData = createTemplateSchema.parse(req.body);
-    
+
     // Ensure creator profile exists
     await storage.getOrCreateCreatorProfile(userId);
-    
+
     const template = await storage.createTemplate({
       ...validatedData,
       user_id: userId,
-      status: 'draft',
+      status: "draft",
     });
-    
+
     res.status(201).json(template);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ 
-        message: 'Invalid template data', 
-        errors: error.errors 
+      return res.status(400).json({
+        message: "Invalid template data",
+        errors: error.errors,
       });
     }
-    logger.error('Error creating template:', error);
-    res.status(500).json({ message: 'Failed to create template' });
+    logger.error("Error creating template:", error);
+    res.status(500).json({ message: "Failed to create template" });
   }
 });
 
 // GET /api/templates/suggest-price - Get AI-suggested pricing
-router.get('/suggest-price', requireAuth, async (req, res) => {
+router.get("/suggest-price", requireAuth, async (req, res) => {
   try {
-    const { 
-      duration, 
-      activityCount, 
+    const {
+      duration,
+      activityCount,
       destinations,
       tags,
       hasFlights,
       hasHotels,
-      hasMeals
+      hasMeals,
     } = req.query;
 
-    const { pricingSuggestionService } = await import('../services/pricingSuggestionService');
-    
-    // Get user's creator score
-    const creator = await storage.getCreatorProfile(req.user!.id);
-    
-    // Get similar templates prices
-    const similarPrices = await pricingSuggestionService.getSimilarTemplatesPrices(
-      parseInt(String(duration || '7')),
-      String(destinations || '').split(',').filter(Boolean),
-      storage
+    const { pricingSuggestionService } = await import(
+      "../services/pricingSuggestionService"
     );
 
+    // Get user's creator score
+    const user = await storage.getUserById(req.user!.id);
+
+    // Get similar templates prices
+    const similarPrices =
+      await pricingSuggestionService.getSimilarTemplatesPrices(
+        parseInt(String(duration || "7")),
+        String(destinations || "")
+          .split(",")
+          .filter(Boolean),
+        storage,
+      );
+
     const suggestion = pricingSuggestionService.calculateSuggestedPrice({
-      duration: parseInt(String(duration || '7')),
-      activityCount: parseInt(String(activityCount || '0')),
-      hasFlights: hasFlights === 'true',
-      hasHotels: hasHotels === 'true',
-      hasMeals: hasMeals === 'true',
+      duration: parseInt(String(duration || "7")),
+      activityCount: parseInt(String(activityCount || "0")),
+      hasFlights: hasFlights === "true",
+      hasHotels: hasHotels === "true",
+      hasMeals: hasMeals === "true",
       hasTransportation: false,
-      destinations: String(destinations || '').split(',').filter(Boolean),
-      tags: String(tags || '').split(',').filter(Boolean),
-      creatorScore: creator?.creator_score,
-      similarTemplatesPrices: similarPrices
+      destinations: String(destinations || "")
+        .split(",")
+        .filter(Boolean),
+      tags: String(tags || "")
+        .split(",")
+        .filter(Boolean),
+      creatorScore: user?.creator_score ?? undefined,
+      similarTemplatesPrices: similarPrices,
     });
 
     res.json(suggestion);
   } catch (error) {
-    logger.error('Error suggesting price:', error);
-    res.status(500).json({ message: 'Failed to suggest price' });
+    logger.error("Error suggesting price:", error);
+    res.status(500).json({ message: "Failed to suggest price" });
   }
 });
 
 // POST /api/templates/from-trip/:tripId - Create template from existing trip
-router.post('/from-trip/:tripId', requireAuth, async (req, res) => {
+router.post("/from-trip/:tripId", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const { tripId } = req.params;
     const { title, description, price, tags, coverImage } = req.body;
-    
+
     // Get the trip
     const trip = await storage.getTrip(parseInt(tripId));
     if (!trip || trip.user_id !== userId) {
-      return res.status(404).json({ message: 'Trip not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Trip not found or access denied" });
     }
-    
+
     // Enhanced anti-piracy check using multiple detection methods
-    const { antiPiracyService } = await import('../services/antiPiracyService');
-    const piracyCheck = await antiPiracyService.detectPiratedContent(parseInt(tripId), userId);
-    
+    const { antiPiracyService } = await import("../services/antiPiracyService");
+    const piracyCheck = await antiPiracyService.detectPiratedContent(
+      parseInt(tripId),
+      userId,
+    );
+
     if (piracyCheck.isPirated) {
-      logger.warn(`Anti-piracy blocked: User ${userId} attempted to create template from trip ${tripId}. Reason: ${piracyCheck.reason}. Confidence: ${piracyCheck.confidence}%`);
-      
+      logger.warn(
+        `Anti-piracy blocked: User ${userId} attempted to create template from trip ${tripId}. Reason: ${piracyCheck.reason}. Confidence: ${piracyCheck.confidence}%`,
+      );
+
       // Different messages based on confidence level
       if (piracyCheck.confidence >= 90) {
-        return res.status(403).json({ 
-          message: 'This trip contains content from a purchased template and cannot be resold. Please create original content for your templates.' 
+        return res.status(403).json({
+          message:
+            "This trip contains content from a purchased template and cannot be resold. Please create original content for your templates.",
         });
       } else if (piracyCheck.confidence >= 70) {
-        return res.status(403).json({ 
-          message: 'This trip appears to be based on purchased content. Templates must contain original itineraries.' 
+        return res.status(403).json({
+          message:
+            "This trip appears to be based on purchased content. Templates must contain original itineraries.",
         });
       } else {
-        return res.status(403).json({ 
-          message: 'This trip may contain copyrighted content. Please ensure your templates are original creations.' 
+        return res.status(403).json({
+          message:
+            "This trip may contain copyrighted content. Please ensure your templates are original creations.",
         });
       }
     }
-    
+
     // Also check for duplicate content against ALL published templates
-    const duplicateCheck = await antiPiracyService.checkForDuplicateContent(parseInt(tripId), userId);
+    const duplicateCheck = await antiPiracyService.checkForDuplicateContent(
+      parseInt(tripId),
+      userId,
+    );
     if (duplicateCheck.isDuplicate) {
-      logger.warn(`Duplicate content: User ${userId} trip ${tripId} is ${(duplicateCheck.similarity! * 100).toFixed(1)}% similar to template ${duplicateCheck.similarTemplateId}`);
-      return res.status(403).json({ 
-        message: 'This itinerary is too similar to an existing template. Please create unique content to differentiate your offering.' 
+      logger.warn(
+        `Duplicate content: User ${userId} trip ${tripId} is ${(duplicateCheck.similarity! * 100).toFixed(1)}% similar to template ${duplicateCheck.similarTemplateId}`,
+      );
+      return res.status(403).json({
+        message:
+          "This itinerary is too similar to an existing template. Please create unique content to differentiate your offering.",
       });
     }
-    
+
     // Get trip activities
     const activities = await storage.getActivitiesByTripId(parseInt(tripId));
-    
+
     // Import geocoding service if we need it
-    const { geocodingService } = await import('../services/geocodingService');
-    
+    const { geocodingService } = await import("../services/geocodingService");
+
     // Calculate duration
     const startDate = new Date(trip.start_date);
     const endDate = new Date(trip.end_date);
-    const duration = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-    
+    const duration =
+      Math.ceil(
+        (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+      ) + 1;
+
     // Prepare destinations
     const destinations = [];
     if (trip.city) destinations.push(trip.city);
     if (trip.country && !destinations.includes(trip.country)) {
       destinations.push(trip.country);
     }
-    
+
     // Process activities and ensure they have coordinates
-    const processedActivities = await Promise.all(activities.map(async (a) => {
-      let latitude = a.latitude;
-      let longitude = a.longitude;
-      
-      // If activity is missing coordinates but has a location name, geocode it
-      if ((!latitude || !longitude) && a.location_name) {
-        const geocoded = await geocodingService.geocodeWithFallback(
-          a.location_name,
-          trip.city || trip.country // Use trip's city as context
-        );
-        if (geocoded) {
-          latitude = geocoded.latitude;
-          longitude = geocoded.longitude;
-          logger.info(`Geocoded template activity: ${a.location_name} in ${trip.city} -> ${latitude}, ${longitude}`);
+    const processedActivities = await Promise.all(
+      activities.map(async (a) => {
+        let latitude = a.latitude;
+        let longitude = a.longitude;
+
+        // If activity is missing coordinates but has a location name, geocode it
+        if ((!latitude || !longitude) && a.location_name) {
+            const geocoded = await geocodingService.geocodeWithFallback(
+              a.location_name,
+              trip.city || trip.country || undefined, // Use trip's city as context
+            );
+          if (geocoded) {
+            latitude = geocoded.latitude;
+            longitude = geocoded.longitude;
+            logger.info(
+              `Geocoded template activity: ${a.location_name} in ${trip.city} -> ${latitude}, ${longitude}`,
+            );
+          }
         }
-      }
-      
-      return {
-        title: a.title,
-        date: a.date,
-        time: a.time,
-        locationName: a.location_name,
-        latitude,
-        longitude,
-        notes: a.notes,
-        tag: a.tag,
-        order: a.order,
-        travelMode: a.travel_mode,
-      };
-    }));
-    
+
+        return {
+          title: a.title,
+          date: a.date,
+          time: a.time,
+          locationName: a.location_name,
+          latitude,
+          longitude,
+          notes: a.notes,
+          tag: a.tag,
+          order: a.order,
+          travelMode: a.travel_mode,
+        };
+      }),
+    );
+
     // Create trip data JSON with geocoded activities
     const tripData = {
       title: trip.title,
@@ -451,211 +437,240 @@ router.post('/from-trip/:tripId', requireAuth, async (req, res) => {
       hotelLongitude: trip.hotel_longitude,
       activities: processedActivities,
     };
-    
+
     // Create the template
     const template = await storage.createTemplate({
       user_id: userId,
       title: title || `${trip.title} Itinerary`,
-      description: description || `A ${duration}-day trip to ${trip.city || 'an amazing destination'}`,
+      description:
+        description ||
+        `A ${duration}-day trip to ${trip.city || "an amazing destination"}`,
       price: price || 0,
-      currency: 'USD',
+      currency: "USD",
       cover_image: coverImage,
       destinations,
       duration,
       trip_data: tripData,
       tags: tags || [],
-      status: 'draft',
+      status: "draft",
     });
-    
+
     res.status(201).json(template);
   } catch (error) {
-    logger.error('Error creating template from trip:', error);
-    res.status(500).json({ message: 'Failed to create template from trip' });
+    logger.error("Error creating template from trip:", error);
+    res.status(500).json({ message: "Failed to create template from trip" });
   }
 });
 
 // PUT /api/templates/:id - Update template
-router.put('/:id', requireAuth, async (req, res) => {
+router.put("/:id", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
-    
+
     // Check ownership
     const template = await storage.getTemplate(templateId);
     if (!template || template.user_id !== userId) {
-      return res.status(404).json({ message: 'Template not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Template not found or access denied" });
     }
-    
+
     const updated = await storage.updateTemplate(templateId, req.body);
     res.json(updated);
   } catch (error) {
-    logger.error('Error updating template:', error);
-    res.status(500).json({ message: 'Failed to update template' });
+    logger.error("Error updating template:", error);
+    res.status(500).json({ message: "Failed to update template" });
   }
 });
 
 // POST /api/templates/:id/publish - Publish template with quality checks
-router.post('/:id/publish', requireAuth, async (req, res) => {
+router.post("/:id/publish", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
-    
+
     // Check ownership
     const template = await storage.getTemplate(templateId);
     if (!template || template.user_id !== userId) {
-      return res.status(404).json({ message: 'Template not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Template not found or access denied" });
     }
-    
+
     // Run quality checks
     const qualityResult = await templateQualityService.checkTemplateQuality({
       title: template.title,
-      description: template.description || '',
-      price: parseFloat(template.price || '0'),
+      description: template.description || "",
+      price: parseFloat(template.price || "0"),
       tripData: template.trip_data as any,
-      tags: template.tags as string[] || [],
-      destinations: template.destinations as string[] || [],
+      tags: (template.tags as string[]) || [],
+      destinations: (template.destinations as string[]) || [],
       duration: template.duration || 0,
-      userId: userId
+      userId: userId,
     });
-    
+
     // Update quality score in database
-    await templateQualityService.updateTemplateQuality(templateId, qualityResult);
-    
+    await templateQualityService.updateTemplateQuality(
+      templateId,
+      qualityResult,
+    );
+
     // Check if template passes quality threshold
     if (!qualityResult.passed) {
-      return res.status(400).json({ 
-        message: 'Template does not meet quality standards',
+      return res.status(400).json({
+        message: "Template does not meet quality standards",
         qualityScore: qualityResult.score,
         issues: qualityResult.issues,
-        minimumScore: 40
+        minimumScore: 40,
       });
     }
-    
+
     // Run auto-moderation for trusted creators
-    const autoModResult = await templateQualityService.autoModerateTemplate(templateId, userId);
-    
+    const autoModResult = await templateQualityService.autoModerateTemplate(
+      templateId,
+      userId,
+    );
+
     if (autoModResult.autoApproved) {
-      logger.info(`Template ${templateId} auto-approved: ${autoModResult.reason}`);
-      
-      return res.json({ 
-        message: 'Template submitted and automatically approved!',
+      logger.info(
+        `Template ${templateId} auto-approved: ${autoModResult.reason}`,
+      );
+
+      return res.json({
+        message: "Template submitted and automatically approved!",
         templateId,
-        status: 'published',
+        status: "published",
         qualityScore: qualityResult.score,
         autoApproved: true,
-        approvalReason: autoModResult.reason
+        approvalReason: autoModResult.reason,
       });
     }
-    
+
     // If quality score is high enough, auto-approve
-    let status = 'published';
-    let moderationStatus = 'pending';
-    
+    let status = "published";
+    let moderationStatus = "pending";
+
     if (qualityResult.score >= 70) {
       // High quality - auto-approve
-      moderationStatus = 'approved';
+      moderationStatus = "approved";
     } else {
       // Medium quality - needs review
-      status = 'draft'; // Keep as draft until reviewed
-      logger.info(`Template ${templateId} needs manual review. Score: ${qualityResult.score}`);
+      status = "draft"; // Keep as draft until reviewed
+      logger.info(
+        `Template ${templateId} needs manual review. Score: ${qualityResult.score}`,
+      );
     }
-    
-    const updated = await storage.updateTemplate(templateId, { 
+
+    const updated = await storage.updateTemplate(templateId, {
       status,
       moderation_status: moderationStatus,
-      quality_score: qualityResult.score
+      quality_score: qualityResult.score,
     });
-    
+
     res.json({
       ...updated,
       qualityScore: qualityResult.score,
       moderationStatus,
-      message: qualityResult.score >= 70 
-        ? 'Template published successfully!' 
-        : 'Template submitted for review. You will be notified once approved.'
+      message:
+        qualityResult.score >= 70
+          ? "Template published successfully!"
+          : "Template submitted for review. You will be notified once approved.",
     });
   } catch (error) {
-    logger.error('Error publishing template:', error);
-    res.status(500).json({ message: 'Failed to publish template' });
+    logger.error("Error publishing template:", error);
+    res.status(500).json({ message: "Failed to publish template" });
   }
 });
 
 // POST /api/templates/:id/unpublish - Unpublish template
-router.post('/:id/unpublish', requireAuth, async (req, res) => {
+router.post("/:id/unpublish", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
-    
+
     // Check ownership
     const template = await storage.getTemplate(templateId);
     if (!template || template.user_id !== userId) {
-      return res.status(404).json({ message: 'Template not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Template not found or access denied" });
     }
-    
-    const updated = await storage.updateTemplate(templateId, { status: 'draft' });
+
+    const updated = await storage.updateTemplate(templateId, {
+      status: "draft",
+    });
     res.json(updated);
   } catch (error) {
-    logger.error('Error unpublishing template:', error);
-    res.status(500).json({ message: 'Failed to unpublish template' });
+    logger.error("Error unpublishing template:", error);
+    res.status(500).json({ message: "Failed to unpublish template" });
   }
 });
 
 // DELETE /api/templates/:id - Delete template
-router.delete('/:id', requireAuth, async (req, res) => {
+router.delete("/:id", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
-    
+
     // Check ownership
     const template = await storage.getTemplate(templateId);
     if (!template || template.user_id !== userId) {
-      return res.status(404).json({ message: 'Template not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Template not found or access denied" });
     }
-    
+
     // Don't allow deletion if template has sales
     if ((template.sales_count || 0) > 0) {
-      return res.status(400).json({ 
-        message: 'Cannot delete template with existing sales. Unpublish instead.' 
+      return res.status(400).json({
+        message:
+          "Cannot delete template with existing sales. Unpublish instead.",
       });
     }
-    
+
     await storage.deleteTemplate(templateId);
-    res.json({ message: 'Template deleted successfully' });
+    res.json({ message: "Template deleted successfully" });
   } catch (error) {
-    logger.error('Error deleting template:', error);
-    res.status(500).json({ message: 'Failed to delete template' });
+    logger.error("Error deleting template:", error);
+    res.status(500).json({ message: "Failed to delete template" });
   }
 });
 
 // POST /api/templates/:id/purchase - Purchase template
-router.post('/:id/purchase', requireAuth, async (req, res) => {
+router.post("/:id/purchase", requireAuth, async (req, res) => {
   try {
     const buyerId = req.user!.id;
     const templateId = parseInt(req.params.id);
     const { paymentIntentId } = req.body;
-    
+
     // Get template
     const template = await storage.getTemplate(templateId);
-    if (!template || template.status !== 'published') {
-      return res.status(404).json({ message: 'Template not found or not available' });
+    if (!template || template.status !== "published") {
+      return res
+        .status(404)
+        .json({ message: "Template not found or not available" });
     }
-    
+
     // Check if already purchased
-    const alreadyPurchased = await storage.hasUserPurchasedTemplate(buyerId, templateId);
+    const alreadyPurchased = await storage.hasUserPurchasedTemplate(
+      buyerId,
+      templateId,
+    );
     if (alreadyPurchased) {
-      return res.status(400).json({ message: 'Template already purchased' });
+      return res.status(400).json({ message: "Template already purchased" });
     }
-    
+
     // Calculate fees - Industry standard: deduct Stripe fees first
-    const grossPrice = parseFloat(template.price || '0');
+    const grossPrice = parseFloat(template.price || "0");
     // Stripe fees: 2.9% + $0.30 per transaction
-    const stripeFee = (grossPrice * 0.029) + 0.30;
+    const stripeFee = grossPrice * 0.029 + 0.3;
     const netRevenue = grossPrice - stripeFee;
-    
+
     // Split net revenue: 70% to creator, 30% to platform
-    const sellerEarnings = netRevenue * 0.70;
-    const platformFee = netRevenue * 0.30;
-    
+    const sellerEarnings = netRevenue * 0.7;
+    const platformFee = netRevenue * 0.3;
+
     // Create purchase record
     const purchase = await storage.createTemplatePurchase({
       template_id: templateId,
@@ -666,48 +681,62 @@ router.post('/:id/purchase', requireAuth, async (req, res) => {
       seller_earnings: sellerEarnings.toFixed(2),
       stripe_fee: stripeFee.toFixed(2),
       stripe_payment_intent_id: paymentIntentId,
-      status: 'completed',
+      status: "completed",
     });
-    
+
     // Copy template to user's trips
-    const { templateCopyService } = await import('../services/templateCopyService');
-    const newTripId = await templateCopyService.copyTemplateToTrip(templateId, buyerId);
-    
+    const { templateCopyService } = await import(
+      "../services/templateCopyService"
+    );
+    const newTripId = await templateCopyService.copyTemplateToTrip(
+      templateId,
+      buyerId,
+    );
+
     res.json({
-      message: 'Template purchased successfully',
+      message: "Template purchased successfully",
       purchase,
       tripId: newTripId,
     });
   } catch (error) {
-    logger.error('Error purchasing template:', error);
-    res.status(500).json({ message: 'Failed to purchase template' });
+    logger.error("Error purchasing template:", error);
+    res.status(500).json({ message: "Failed to purchase template" });
   }
 });
 
 // POST /api/templates/:id/review - Add review
-router.post('/:id/review', requireAuth, async (req, res) => {
+router.post("/:id/review", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
     const { rating, review } = req.body;
-    
+
     // Validate rating
     if (!rating || rating < 1 || rating > 5) {
-      return res.status(400).json({ message: 'Rating must be between 1 and 5' });
+      return res
+        .status(400)
+        .json({ message: "Rating must be between 1 and 5" });
     }
-    
+
     // Check if user purchased the template
-    const hasPurchased = await storage.hasUserPurchasedTemplate(userId, templateId);
+    const hasPurchased = await storage.hasUserPurchasedTemplate(
+      userId,
+      templateId,
+    );
     if (!hasPurchased) {
-      return res.status(403).json({ message: 'You must purchase the template to review it' });
+      return res
+        .status(403)
+        .json({ message: "You must purchase the template to review it" });
     }
-    
+
     // Check if already reviewed
     const existingReview = await storage.getUserReview(userId, templateId);
     if (existingReview) {
-      return res.status(400).json({ message: 'You have already reviewed this template' });
+      return res
+        .status(400)
+        .json({ message: "You have already reviewed this template" });
     }
-    
+
     // Create review
     const newReview = await storage.createTemplateReview({
       template_id: templateId,
@@ -716,75 +745,88 @@ router.post('/:id/review', requireAuth, async (req, res) => {
       review,
       verified_purchase: true,
     });
-    
+
     res.status(201).json(newReview);
   } catch (error) {
-    logger.error('Error creating review:', error);
-    res.status(500).json({ message: 'Failed to create review' });
+    logger.error("Error creating review:", error);
+    res.status(500).json({ message: "Failed to create review" });
   }
 });
 
 // GET /api/templates/:id/analytics - Get template analytics (creator only)
-router.get('/:id/analytics', requireAuth, async (req, res) => {
+router.get("/:id/analytics", requireAuth, async (req, res) => {
   try {
     const userId = req.user!.id;
     const templateId = parseInt(req.params.id);
-    
+
     // Check ownership
     const template = await storage.getTemplate(templateId);
     if (!template || template.user_id !== userId) {
-      return res.status(404).json({ message: 'Template not found or access denied' });
+      return res
+        .status(404)
+        .json({ message: "Template not found or access denied" });
     }
-    
+
     // Get purchases
     const purchases = await storage.getTemplatePurchases(templateId);
-    
+
     // Calculate analytics
     const analytics = {
       views: template.view_count,
       sales: template.sales_count,
-      revenue: purchases.reduce((sum, p) => sum + parseFloat(p.seller_earnings || '0'), 0),
-      conversionRate: (template.view_count || 0) > 0 ? ((template.sales_count || 0) / (template.view_count || 1) * 100).toFixed(2) : 0,
+      revenue: purchases.reduce(
+        (sum, p) => sum + parseFloat(p.seller_earnings || "0"),
+        0,
+      ),
+      conversionRate:
+        (template.view_count || 0) > 0
+          ? (
+              ((template.sales_count || 0) / (template.view_count || 1)) *
+              100
+            ).toFixed(2)
+          : 0,
       averageRating: template.rating || 0,
       reviewCount: template.review_count,
       recentPurchases: purchases.slice(0, 10),
     };
-    
+
     res.json(analytics);
   } catch (error) {
-    logger.error('Error fetching template analytics:', error);
-    res.status(500).json({ message: 'Failed to fetch analytics' });
+    logger.error("Error fetching template analytics:", error);
+    res.status(500).json({ message: "Failed to fetch analytics" });
   }
 });
 
 // GET /api/templates/share/:shareCode - Get template by share code or slug
-router.get('/share/:shareCode', async (req, res) => {
+router.get("/share/:shareCode", async (req, res) => {
   try {
     const { shareCode } = req.params;
-    
+
     // First try to get by share code
     let template = await storage.getTemplateByShareCode(shareCode);
-    
+
     // If not found, try treating it as a slug (for backward compatibility)
     if (!template) {
       template = await storage.getTemplateBySlug(shareCode);
     }
-    
+
     if (!template) {
-      return res.status(404).json({ message: 'Template not found' });
+      return res.status(404).json({ message: "Template not found" });
     }
-    
+
     // Get creator info
-    const creator = template.user_id ? await storage.getUser(template.user_id) : null;
-    
+    const creator = template.user_id
+      ? await storage.getUser(template.user_id)
+      : null;
+
     // Transform the template data for frontend
-    const tripData = template.trip_data as any || {};
+    const tripData = (template.trip_data as any) || {};
     let activities: any[] = [];
-    
+
     // Calculate a base date for the template (30 days from now)
     const baseDate = new Date();
     baseDate.setDate(baseDate.getDate() + 30);
-    
+
     // Extract activities from the days structure
     if (tripData.days && Array.isArray(tripData.days)) {
       tripData.days.forEach((day: any) => {
@@ -793,67 +835,69 @@ router.get('/share/:shareCode', async (req, res) => {
           const dayDate = new Date(baseDate);
           const dayNumber = parseInt(day.day) || 1;
           dayDate.setDate(dayDate.getDate() + (dayNumber - 1));
-          
+
           day.activities.forEach((activity: any) => {
             activities.push({
               ...activity,
               date: dayDate.toISOString(),
-              day: dayNumber
+              day: dayNumber,
             });
           });
         }
       });
     }
-    
+
     const transformedTemplate = {
       ...template,
       activities: activities,
       tripData: tripData,
-      creator: creator ? {
-        id: creator.id,
-        username: creator.username,
-        displayName: creator.display_name,
-        verified: false
-      } : null
+      creator: creator
+        ? {
+            id: creator.id,
+            username: creator.username,
+            displayName: creator.display_name,
+            verified: false,
+          }
+        : null,
     };
-    
+
     res.json(sanitizeResponseDates(transformedTemplate));
   } catch (error) {
-    logger.error('Error fetching template by share code:', error);
-    res.status(500).json({ message: 'Failed to fetch template' });
+    logger.error("Error fetching template by share code:", error);
+    res.status(500).json({ message: "Failed to fetch template" });
   }
 });
 
 // POST /api/templates/:id/share - Track social share
-router.post('/:id/share', async (req, res) => {
+router.post("/:id/share", async (req, res) => {
   try {
     const templateId = parseInt(req.params.id);
     const { platform } = req.body;
     const userId = req.user?.id;
-    
+
     if (!platform) {
-      return res.status(400).json({ message: 'Platform is required' });
+      return res.status(400).json({ message: "Platform is required" });
     }
-    
+
     const share = await storage.trackTemplateShare({
       template_id: templateId,
       shared_by: userId,
       platform,
     });
-    
+
     res.json({
-      message: 'Share tracked successfully',
+      message: "Share tracked successfully",
       shareCode: share.share_code,
       shareUrl: `${process.env.FRONTEND_URL}/t/${share.share_code}`,
     });
   } catch (error) {
-    logger.error('Error tracking share:', error);
-    res.status(500).json({ message: 'Failed to track share' });
+    logger.error("Error tracking share:", error);
+    res.status(500).json({ message: "Failed to track share" });
   }
 });
 
 // POST /api/templates/reuse - Create a new trip from an owned template
-router.post('/reuse', requireAuth, async (req, res) => {
+router.post("/reuse", requireAuth, async (req, res) => {
   try {
     const { template_id, start_date, end_date } = req.body;
     const userId = req.user!.id;
@@ -861,62 +905,71 @@ router.post('/reuse', requireAuth, async (req, res) => {
     logger.info(`User ${userId} attempting to reuse template ${template_id}`);
 
     if (!template_id || !start_date || !end_date) {
-      return res.status(400).json({ 
-        message: 'Template ID and travel dates are required' 
+      return res.status(400).json({
+        message: "Template ID and travel dates are required",
       });
     }
-    
+
     // Validate dates
     const startDateObj = new Date(start_date);
     const endDateObj = new Date(end_date);
-    
+
     if (isNaN(startDateObj.getTime()) || isNaN(endDateObj.getTime())) {
-      return res.status(400).json({ 
-        message: 'Invalid date format provided' 
+      return res.status(400).json({
+        message: "Invalid date format provided",
       });
     }
-    
+
     if (startDateObj >= endDateObj) {
-      return res.status(400).json({ 
-        message: 'End date must be after start date' 
+      return res.status(400).json({
+        message: "End date must be after start date",
       });
     }
 
     // Verify user has purchased the template
-    const hasPurchased = await storage.hasUserPurchasedTemplate(userId, template_id);
-    
+    const hasPurchased = await storage.hasUserPurchasedTemplate(
+      userId,
+      template_id,
+    );
+
     // Get template details
     const template = await storage.getTemplate(template_id);
     if (!template) {
-      return res.status(404).json({ message: 'Template not found' });
+      return res.status(404).json({ message: "Template not found" });
     }
 
     // Check if user owns the template (either purchased or it's free)
-    if (!hasPurchased && template.price !== '0') {
-      logger.warn(`User ${userId} attempted to reuse unpurchased template ${template_id}`);
-      return res.status(403).json({ 
-        message: 'You must purchase this template before using it' 
+    if (!hasPurchased && template.price !== "0") {
+      logger.warn(
+        `User ${userId} attempted to reuse unpurchased template ${template_id}`,
+      );
+      return res.status(403).json({
+        message: "You must purchase this template before using it",
       });
     }
 
     // Copy template to user's trips with the selected dates
-    const { templateCopyService } = await import('../services/templateCopyService');
+    const { templateCopyService } = await import(
+      "../services/templateCopyService"
+    );
     const newTripId = await templateCopyService.copyTemplateToTrip(
-      template_id, 
+      template_id,
       userId,
       startDateObj,
-      endDateObj
+      endDateObj,
     );
 
-    logger.info(`Template ${template_id} reused by user ${userId}, created trip ${newTripId}`);
+    logger.info(
+      `Template ${template_id} reused by user ${userId}, created trip ${newTripId}`,
+    );
 
     res.json({
-      message: 'Trip created successfully from template',
+      message: "Trip created successfully from template",
       tripId: newTripId,
     });
   } catch (error) {
-    logger.error('Error reusing template:', error);
-    res.status(500).json({ message: 'Failed to create trip from template' });
+    logger.error("Error reusing template:", error);
+    res.status(500).json({ message: "Failed to create trip from template" });
   }
 });
 

--- a/server/services/templateQualityService.ts
+++ b/server/services/templateQualityService.ts
@@ -1,6 +1,6 @@
 import { db } from "../db-connection";
 import { templates, users } from "@shared/schema";
-import { eq } from "drizzle-orm";
+import { eq, sql, and } from "drizzle-orm";
 import { logger } from "../utils/logger";
 
 interface QualityCheckResult {

--- a/server/storage-consumer.ts
+++ b/server/storage-consumer.ts
@@ -1,19 +1,59 @@
-import { db } from './db';
-import { 
-  users, trips, activities, notes, todos, bookings,
-  tripCollaborators, invitations, waitlist,
-  templates, templatePurchases, creatorBalances, templateReviews,
-  templateShares, creatorProfiles, viatorCommissions, templateCollections,
-  insertTripSchema, insertActivitySchema, insertNoteSchema, 
-  insertTodoSchema, insertBookingSchema, registerUserSchema,
-  User, Trip, Activity, Note, Todo, Booking,
-  Template, TemplatePurchase, CreatorBalance, TemplateReview,
-  TemplateShare, CreatorProfile, ViatorCommission, TemplateCollection
-} from '../shared/schema';
-import { eq, and, desc, inArray, sql, or } from 'drizzle-orm';
-import { hashPassword } from './auth';
-import { nanoid } from 'nanoid';
-import { logger } from './utils/logger';
+import { db } from "./db";
+import {
+  users,
+  trips,
+  activities,
+  notes,
+  todos,
+  bookings,
+  tripCollaborators,
+  invitations,
+  waitlist,
+  templates,
+  templatePurchases,
+  creatorBalances,
+  templateReviews,
+  templateShares,
+  creatorProfiles,
+  viatorCommissions,
+  templateCollections,
+  insertTripSchema,
+  insertActivitySchema,
+  insertNoteSchema,
+  insertTodoSchema,
+  insertBookingSchema,
+  registerUserSchema,
+  User,
+  Trip,
+  Activity,
+  Note,
+  Todo,
+  Booking,
+  Template,
+  TemplatePurchase,
+  CreatorBalance,
+  TemplateReview,
+  TemplateShare,
+  CreatorProfile,
+  ViatorCommission,
+  TemplateCollection,
+} from "../shared/schema";
+import {
+  eq,
+  and,
+  desc,
+  asc,
+  inArray,
+  sql,
+  or,
+  gte,
+  lte,
+  ilike,
+  SQL,
+} from "drizzle-orm";
+import { hashPassword } from "./auth";
+import { nanoid } from "nanoid";
+import { logger } from "./utils/logger";
 
 // Simple storage interface for consumer app
 export interface IStorage {
@@ -24,25 +64,28 @@ export interface IStorage {
   getUserByEmail(email: string): Promise<User | undefined>;
   getUserByUsername(username: string): Promise<User | undefined>;
   updateUser(id: number, updates: Partial<User>): Promise<User | undefined>;
-  
+
   // Trip management
   createTrip(tripData: any): Promise<Trip>;
   getTrip(id: number): Promise<Trip | undefined>; // Alias for getTripById
   getTripById(id: number): Promise<Trip | undefined>;
-  getTripsByUserId(userId: number, organizationId?: number | null): Promise<Trip[]>;
+  getTripsByUserId(
+    userId: number,
+    organizationId?: number | null,
+  ): Promise<Trip[]>;
   getTripsByOrganizationId(organizationId: number): Promise<Trip[]>;
   updateTrip(id: number, updates: any): Promise<Trip | undefined>;
   deleteTrip(id: number): Promise<boolean>;
   getPublicTrips(): Promise<Trip[]>;
   getTripByShareCode(shareCode: string): Promise<Trip | undefined>;
-  
+
   // Activity management
   createActivity(activityData: any): Promise<Activity>;
   getActivitiesByTripId(tripId: number): Promise<Activity[]>;
   getActivity(id: number): Promise<Activity | undefined>;
   updateActivity(id: number, updates: any): Promise<Activity | undefined>;
   deleteActivity(id: number): Promise<boolean>;
-  
+
   // Notes & Todos
   createNote(noteData: any): Promise<Note>;
   getNotesByTripId(tripId: number): Promise<Note[]>;
@@ -50,53 +93,78 @@ export interface IStorage {
   getTodosByTripId(tripId: number): Promise<Todo[]>;
   updateTodo(id: number, updates: any): Promise<Todo | undefined>;
   deleteTodo(id: number): Promise<boolean>;
-  
+
   // Bookings
   createBooking(bookingData: any): Promise<Booking>;
   getBookingsByUserId(userId: number): Promise<Booking[]>;
   updateBooking(id: number, updates: any): Promise<Booking | undefined>;
-  
+
   // Collaboration
-  addTripCollaborator(tripId: number, userId: number, role: string): Promise<any>;
+  addTripCollaborator(
+    tripId: number,
+    userId: number,
+    role: string,
+  ): Promise<any>;
   getTripCollaborators(tripId: number): Promise<any[]>;
   removeTripCollaborator(tripId: number, userId: number): Promise<boolean>;
-  
+
   // Waitlist
   addToWaitlist(email: string, referralSource?: string): Promise<any>;
-  
+
   // Template management
   createTemplate(templateData: any): Promise<Template>;
   getTemplate(id: number): Promise<Template | undefined>;
   getTemplateBySlug(slug: string): Promise<Template | undefined>;
   getTemplatesByUserId(userId: number): Promise<Template[]>;
   getPublishedTemplates(): Promise<Template[]>;
-  searchTemplates(query: string, filters?: any): Promise<Template[]>;
+  searchTemplates(params: {
+    search?: string;
+    tag?: string;
+    minPrice?: number;
+    maxPrice?: number;
+    duration?: number;
+    destination?: string;
+    sort?: string;
+  }): Promise<Template[]>;
   updateTemplate(id: number, updates: any): Promise<Template | undefined>;
   deleteTemplate(id: number): Promise<boolean>;
   incrementTemplateViews(id: number): Promise<void>;
-  
+
   // Template purchases
   createTemplatePurchase(purchaseData: any): Promise<TemplatePurchase>;
   getTemplatePurchases(templateId: number): Promise<TemplatePurchase[]>;
   getUserPurchases(userId: number): Promise<TemplatePurchase[]>;
-  hasUserPurchasedTemplate(userId: number, templateId: number): Promise<boolean>;
-  
+  hasUserPurchasedTemplate(
+    userId: number,
+    templateId: number,
+  ): Promise<boolean>;
+
   // Creator profiles
   getOrCreateCreatorProfile(userId: number): Promise<CreatorProfile>;
-  updateCreatorProfile(userId: number, updates: any): Promise<CreatorProfile | undefined>;
+  updateCreatorProfile(
+    userId: number,
+    updates: any,
+  ): Promise<CreatorProfile | undefined>;
   getCreatorProfile(userId: number): Promise<CreatorProfile | undefined>;
-  
+
   // Creator balances
   getOrCreateCreatorBalance(userId: number): Promise<CreatorBalance>;
-  updateCreatorBalance(userId: number, amount: number, type: 'add' | 'subtract'): Promise<CreatorBalance>;
+  updateCreatorBalance(
+    userId: number,
+    amount: number,
+    type: "add" | "subtract",
+  ): Promise<CreatorBalance>;
   getCreatorBalance(userId: number): Promise<CreatorBalance | undefined>;
-  
+
   // Template reviews
   createTemplateReview(reviewData: any): Promise<TemplateReview>;
   getTemplateReviews(templateId: number): Promise<TemplateReview[]>;
-  getUserReview(userId: number, templateId: number): Promise<TemplateReview | undefined>;
+  getUserReview(
+    userId: number,
+    templateId: number,
+  ): Promise<TemplateReview | undefined>;
   updateTemplateRating(templateId: number): Promise<void>;
-  
+
   // Template sharing
   trackTemplateShare(shareData: any): Promise<TemplateShare>;
   incrementShareClicks(shareCode: string): Promise<void>;
@@ -110,18 +178,21 @@ export class ConsumerDatabaseStorage implements IStorage {
   async createUser(userData: any): Promise<User> {
     const validatedData = registerUserSchema.parse(userData);
     const hashedPassword = hashPassword(validatedData.password);
-    
-    const [newUser] = await db.insert(users).values({
-      auth_id: `local_${validatedData.username}_${Date.now()}`, // Generate auth_id for local auth
-      username: validatedData.username,
-      email: validatedData.email,
-      password_hash: hashedPassword,
-      display_name: validatedData.display_name,
-      role: 'user', // Always regular user for consumers
-      role_type: 'consumer',
-      organization_id: null, // No organizations in consumer app
-    }).returning();
-    
+
+    const [newUser] = await db
+      .insert(users)
+      .values({
+        auth_id: `local_${validatedData.username}_${Date.now()}`, // Generate auth_id for local auth
+        username: validatedData.username,
+        email: validatedData.email,
+        password_hash: hashedPassword,
+        display_name: validatedData.display_name,
+        role: "user", // Always regular user for consumers
+        role_type: "consumer",
+        organization_id: null, // No organizations in consumer app
+      })
+      .returning();
+
     return newUser;
   }
 
@@ -130,22 +201,38 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async getUserById(id: number): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.id, id)).limit(1);
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, id))
+      .limit(1);
     return user;
   }
 
   async getUserByEmail(email: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.email, email)).limit(1);
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
     return user;
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.username, username)).limit(1);
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.username, username))
+      .limit(1);
     return user;
   }
 
-  async updateUser(id: number, updates: Partial<User>): Promise<User | undefined> {
-    const [updated] = await db.update(users)
+  async updateUser(
+    id: number,
+    updates: Partial<User>,
+  ): Promise<User | undefined> {
+    const [updated] = await db
+      .update(users)
       .set(updates)
       .where(eq(users.id, id))
       .returning();
@@ -156,30 +243,33 @@ export class ConsumerDatabaseStorage implements IStorage {
   async createTrip(tripData: any): Promise<Trip> {
     const insertTrip = insertTripSchema.parse(tripData);
     const shareCode = nanoid(8);
-    
-    const [newTrip] = await db.insert(trips).values({
-      title: insertTrip.title,
-      start_date: insertTrip.start_date,
-      end_date: insertTrip.end_date,
-      user_id: insertTrip.user_id,
-      organization_id: null, // Always null for consumers
-      share_code: shareCode,
-      sharing_enabled: insertTrip.sharingEnabled || false,
-      share_permission: insertTrip.sharePermission || 'read-only',
-      is_public: insertTrip.isPublic || false,
-      city: insertTrip.city,
-      country: insertTrip.country,
-      location: insertTrip.location,
-      city_latitude: insertTrip.city_latitude,
-      city_longitude: insertTrip.city_longitude,
-      hotel: insertTrip.hotel,
-      hotel_latitude: insertTrip.hotel_latitude,
-      hotel_longitude: insertTrip.hotel_longitude,
-      trip_type: 'personal', // Always personal for consumers
-      budget: insertTrip.budget,
-      collaborators: [],
-    }).returning();
-    
+
+    const [newTrip] = await db
+      .insert(trips)
+      .values({
+        title: insertTrip.title,
+        start_date: insertTrip.start_date,
+        end_date: insertTrip.end_date,
+        user_id: insertTrip.user_id,
+        organization_id: null, // Always null for consumers
+        share_code: shareCode,
+        sharing_enabled: insertTrip.sharingEnabled || false,
+        share_permission: insertTrip.sharePermission || "read-only",
+        is_public: insertTrip.isPublic || false,
+        city: insertTrip.city,
+        country: insertTrip.country,
+        location: insertTrip.location,
+        city_latitude: insertTrip.city_latitude,
+        city_longitude: insertTrip.city_longitude,
+        hotel: insertTrip.hotel,
+        hotel_latitude: insertTrip.hotel_latitude,
+        hotel_longitude: insertTrip.hotel_longitude,
+        trip_type: "personal", // Always personal for consumers
+        budget: insertTrip.budget,
+        collaborators: [],
+      })
+      .returning();
+
     return newTrip;
   }
 
@@ -188,28 +278,41 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async getTripById(id: number): Promise<Trip | undefined> {
-    const [trip] = await db.select().from(trips).where(eq(trips.id, id)).limit(1);
+    const [trip] = await db
+      .select()
+      .from(trips)
+      .where(eq(trips.id, id))
+      .limit(1);
     return trip;
   }
 
-  async getTripsByUserId(userId: number, organizationId?: number | null): Promise<Trip[]> {
+  async getTripsByUserId(
+    userId: number,
+    organizationId?: number | null,
+  ): Promise<Trip[]> {
     // Get trips where user is owner or collaborator
-    const ownTrips = await db.select()
+    const ownTrips = await db
+      .select()
       .from(trips)
       .where(eq(trips.user_id, userId))
       .orderBy(desc(trips.start_date));
-      
-    const collaboratingTrips = await db.select()
+
+    const collaboratingTrips = await db
+      .select()
       .from(trips)
       .innerJoin(tripCollaborators, eq(trips.id, tripCollaborators.trip_id))
-      .where(and(
-        eq(tripCollaborators.user_id, userId),
-        eq(tripCollaborators.status, 'accepted')
-      ))
+      .where(
+        and(
+          eq(tripCollaborators.user_id, userId),
+          eq(tripCollaborators.status, "accepted"),
+        ),
+      )
       .orderBy(desc(trips.start_date));
-    
-    const allTrips = [...ownTrips, ...collaboratingTrips.map(t => t.trips)];
-    return allTrips.sort((a, b) => b.start_date.getTime() - a.start_date.getTime());
+
+    const allTrips = [...ownTrips, ...collaboratingTrips.map((t) => t.trips)];
+    return allTrips.sort(
+      (a, b) => b.start_date.getTime() - a.start_date.getTime(),
+    );
   }
 
   async getTripsByOrganizationId(organizationId: number): Promise<Trip[]> {
@@ -218,7 +321,8 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async updateTrip(id: number, updates: any): Promise<Trip | undefined> {
-    const [updated] = await db.update(trips)
+    const [updated] = await db
+      .update(trips)
       .set(updates)
       .where(eq(trips.id, id))
       .returning();
@@ -226,12 +330,16 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async deleteTrip(id: number): Promise<boolean> {
-    const result = await db.delete(trips).where(eq(trips.id, id)).returning({ id: trips.id });
+    const result = await db
+      .delete(trips)
+      .where(eq(trips.id, id))
+      .returning({ id: trips.id });
     return result.length > 0;
   }
 
   async getPublicTrips(): Promise<Trip[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(trips)
       .where(eq(trips.is_public, true))
       .orderBy(desc(trips.created_at))
@@ -239,12 +347,12 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async getTripByShareCode(shareCode: string): Promise<Trip | undefined> {
-    const [trip] = await db.select()
+    const [trip] = await db
+      .select()
       .from(trips)
-      .where(and(
-        eq(trips.share_code, shareCode),
-        eq(trips.sharing_enabled, true)
-      ))
+      .where(
+        and(eq(trips.share_code, shareCode), eq(trips.sharing_enabled, true)),
+      )
       .limit(1);
     return trip;
   }
@@ -252,45 +360,57 @@ export class ConsumerDatabaseStorage implements IStorage {
   // Activity management
   async createActivity(activityData: any): Promise<Activity> {
     const insertActivity = insertActivitySchema.parse(activityData);
-    
-    const [newActivity] = await db.insert(activities).values({
-      trip_id: insertActivity.trip_id,
-      organization_id: null, // Always null for consumers
-      title: insertActivity.title,
-      date: insertActivity.date,
-      time: insertActivity.time,
-      location_name: insertActivity.location_name,
-      latitude: insertActivity.latitude,
-      longitude: insertActivity.longitude,
-      notes: insertActivity.notes,
-      tag: insertActivity.tag,
-      assigned_to: insertActivity.assigned_to,
-      order: insertActivity.order,
-      travel_mode: insertActivity.travel_mode,
-      booking_url: insertActivity.booking_url,
-      booking_reference: insertActivity.booking_reference,
-      price: insertActivity.price,
-      currency: insertActivity.currency,
-      provider: insertActivity.provider,
-    }).returning();
-    
+
+    const [newActivity] = await db
+      .insert(activities)
+      .values({
+        trip_id: insertActivity.trip_id,
+        organization_id: null, // Always null for consumers
+        title: insertActivity.title,
+        date: insertActivity.date,
+        time: insertActivity.time,
+        location_name: insertActivity.location_name,
+        latitude: insertActivity.latitude,
+        longitude: insertActivity.longitude,
+        notes: insertActivity.notes,
+        tag: insertActivity.tag,
+        assigned_to: insertActivity.assigned_to,
+        order: insertActivity.order,
+        travel_mode: insertActivity.travel_mode,
+        booking_url: insertActivity.booking_url,
+        booking_reference: insertActivity.booking_reference,
+        price: insertActivity.price,
+        currency: insertActivity.currency,
+        provider: insertActivity.provider,
+      })
+      .returning();
+
     return newActivity;
   }
 
   async getActivity(id: number): Promise<Activity | undefined> {
-    const [activity] = await db.select().from(activities).where(eq(activities.id, id)).limit(1);
+    const [activity] = await db
+      .select()
+      .from(activities)
+      .where(eq(activities.id, id))
+      .limit(1);
     return activity;
   }
 
   async getActivitiesByTripId(tripId: number): Promise<Activity[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(activities)
       .where(eq(activities.trip_id, tripId))
       .orderBy(activities.date, activities.order);
   }
 
-  async updateActivity(id: number, updates: any): Promise<Activity | undefined> {
-    const [updated] = await db.update(activities)
+  async updateActivity(
+    id: number,
+    updates: any,
+  ): Promise<Activity | undefined> {
+    const [updated] = await db
+      .update(activities)
       .set(updates)
       .where(eq(activities.id, id))
       .returning();
@@ -298,25 +418,32 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async deleteActivity(id: number): Promise<boolean> {
-    const result = await db.delete(activities).where(eq(activities.id, id)).returning({ id: activities.id });
+    const result = await db
+      .delete(activities)
+      .where(eq(activities.id, id))
+      .returning({ id: activities.id });
     return result.length > 0;
   }
 
   // Notes & Todos
   async createNote(noteData: any): Promise<Note> {
     const insertNote = insertNoteSchema.parse(noteData);
-    
-    const [newNote] = await db.insert(notes).values({
-      trip_id: insertNote.trip_id,
-      content: insertNote.content,
-      created_by: insertNote.created_by,
-    }).returning();
-    
+
+    const [newNote] = await db
+      .insert(notes)
+      .values({
+        trip_id: insertNote.trip_id,
+        content: insertNote.content,
+        created_by: insertNote.created_by,
+      })
+      .returning();
+
     return newNote;
   }
 
   async getNotesByTripId(tripId: number): Promise<Note[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(notes)
       .where(eq(notes.trip_id, tripId))
       .orderBy(desc(notes.created_at));
@@ -324,26 +451,31 @@ export class ConsumerDatabaseStorage implements IStorage {
 
   async createTodo(todoData: any): Promise<Todo> {
     const insertTodo = insertTodoSchema.parse(todoData);
-    
-    const [newTodo] = await db.insert(todos).values({
-      trip_id: insertTodo.trip_id,
-      content: insertTodo.content,
-      is_completed: insertTodo.is_completed || false,
-      assigned_to: insertTodo.assigned_to,
-    }).returning();
-    
+
+    const [newTodo] = await db
+      .insert(todos)
+      .values({
+        trip_id: insertTodo.trip_id,
+        content: insertTodo.content,
+        is_completed: insertTodo.is_completed || false,
+        assigned_to: insertTodo.assigned_to,
+      })
+      .returning();
+
     return newTodo;
   }
 
   async getTodosByTripId(tripId: number): Promise<Todo[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(todos)
       .where(eq(todos.trip_id, tripId))
       .orderBy(todos.created_at);
   }
 
   async updateTodo(id: number, updates: any): Promise<Todo | undefined> {
-    const [updated] = await db.update(todos)
+    const [updated] = await db
+      .update(todos)
       .set(updates)
       .where(eq(todos.id, id))
       .returning();
@@ -351,27 +483,35 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   async deleteTodo(id: number): Promise<boolean> {
-    const result = await db.delete(todos).where(eq(todos.id, id)).returning({ id: todos.id });
+    const result = await db
+      .delete(todos)
+      .where(eq(todos.id, id))
+      .returning({ id: todos.id });
     return result.length > 0;
   }
 
   // Bookings
   async createBooking(bookingData: any): Promise<Booking> {
     const insertBooking = insertBookingSchema.parse(bookingData);
-    
-    const [newBooking] = await db.insert(bookings).values(insertBooking).returning();
+
+    const [newBooking] = await db
+      .insert(bookings)
+      .values(insertBooking)
+      .returning();
     return newBooking;
   }
 
   async getBookingsByUserId(userId: number): Promise<Booking[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(bookings)
       .where(eq(bookings.user_id, userId))
       .orderBy(desc(bookings.created_at));
   }
 
   async updateBooking(id: number, updates: any): Promise<Booking | undefined> {
-    const [updated] = await db.update(bookings)
+    const [updated] = await db
+      .update(bookings)
       .set(updates)
       .where(eq(bookings.id, id))
       .returning();
@@ -379,360 +519,532 @@ export class ConsumerDatabaseStorage implements IStorage {
   }
 
   // Collaboration
-  async addTripCollaborator(tripId: number, userId: number, role: string): Promise<any> {
-    const [collaborator] = await db.insert(tripCollaborators).values({
-      trip_id: tripId,
-      user_id: userId,
-      role: role,
-      status: 'pending',
-    }).returning();
-    
+  async addTripCollaborator(
+    tripId: number,
+    userId: number,
+    role: string,
+  ): Promise<any> {
+    const [collaborator] = await db
+      .insert(tripCollaborators)
+      .values({
+        trip_id: tripId,
+        user_id: userId,
+        role: role,
+        status: "pending",
+      })
+      .returning();
+
     return collaborator;
   }
 
   async getTripCollaborators(tripId: number): Promise<any[]> {
-    return await db.select({
-      id: tripCollaborators.id,
-      user_id: tripCollaborators.user_id,
-      role: tripCollaborators.role,
-      status: tripCollaborators.status,
-      user: users,
-    })
-    .from(tripCollaborators)
-    .innerJoin(users, eq(tripCollaborators.user_id, users.id))
-    .where(eq(tripCollaborators.trip_id, tripId));
+    return await db
+      .select({
+        id: tripCollaborators.id,
+        user_id: tripCollaborators.user_id,
+        role: tripCollaborators.role,
+        status: tripCollaborators.status,
+        user: users,
+      })
+      .from(tripCollaborators)
+      .innerJoin(users, eq(tripCollaborators.user_id, users.id))
+      .where(eq(tripCollaborators.trip_id, tripId));
   }
 
-  async removeTripCollaborator(tripId: number, userId: number): Promise<boolean> {
-    const result = await db.delete(tripCollaborators)
-      .where(and(
-        eq(tripCollaborators.trip_id, tripId),
-        eq(tripCollaborators.user_id, userId)
-      ))
+  async removeTripCollaborator(
+    tripId: number,
+    userId: number,
+  ): Promise<boolean> {
+    const result = await db
+      .delete(tripCollaborators)
+      .where(
+        and(
+          eq(tripCollaborators.trip_id, tripId),
+          eq(tripCollaborators.user_id, userId),
+        ),
+      )
       .returning({ id: tripCollaborators.id });
     return result.length > 0;
   }
 
   // Waitlist
   async addToWaitlist(email: string, referralSource?: string): Promise<any> {
-    const [entry] = await db.insert(waitlist).values({
-      email,
-      referral_source: referralSource,
-    }).returning();
-    
+    const [entry] = await db
+      .insert(waitlist)
+      .values({
+        email,
+        referral_source: referralSource,
+      })
+      .returning();
+
     return entry;
   }
-  
+
   // Template management
   async createTemplate(templateData: any): Promise<Template> {
     const slug = await this.generateUniqueSlug(templateData.title);
-    
-    const [newTemplate] = await db.insert(templates).values({
-      ...templateData,
-      slug,
-      status: templateData.status || 'draft',
-      sales_count: 0,
-      view_count: 0,
-      review_count: 0,
-    }).returning();
-    
+
+    const [newTemplate] = await db
+      .insert(templates)
+      .values({
+        ...templateData,
+        slug,
+        status: templateData.status || "draft",
+        sales_count: 0,
+        view_count: 0,
+        review_count: 0,
+      })
+      .returning();
+
     // Update creator profile template count
     await this.incrementCreatorTemplateCount(templateData.user_id);
-    
+
     return newTemplate;
   }
-  
+
   async getTemplate(id: number): Promise<Template | undefined> {
-    const [template] = await db.select().from(templates).where(eq(templates.id, id)).limit(1);
+    const [template] = await db
+      .select()
+      .from(templates)
+      .where(eq(templates.id, id))
+      .limit(1);
     return template;
   }
-  
+
   async getTemplateBySlug(slug: string): Promise<Template | undefined> {
-    const [template] = await db.select().from(templates).where(eq(templates.slug, slug)).limit(1);
+    const [template] = await db
+      .select()
+      .from(templates)
+      .where(eq(templates.slug, slug))
+      .limit(1);
     return template;
   }
-  
+
   async getTemplatesByUserId(userId: number): Promise<Template[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(templates)
       .where(eq(templates.user_id, userId))
       .orderBy(desc(templates.created_at));
   }
-  
+
   async getPublishedTemplates(): Promise<Template[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(templates)
-      .where(eq(templates.status, 'published'))
+      .where(eq(templates.status, "published"))
       .orderBy(desc(templates.created_at));
   }
-  
-  async searchTemplates(query: string, filters?: any): Promise<Template[]> {
-    let baseQuery = db.select().from(templates).where(eq(templates.status, 'published'));
-    
-    // Add search and filters logic here
-    // For now, return all published templates
-    return await baseQuery.orderBy(desc(templates.sales_count));
+
+  async searchTemplates(params: {
+    search?: string;
+    tag?: string;
+    minPrice?: number;
+    maxPrice?: number;
+    duration?: number;
+    destination?: string;
+    sort?: string;
+  }): Promise<Template[]> {
+    const { search, tag, minPrice, maxPrice, duration, destination, sort } =
+      params;
+
+    const conditions: SQL[] = [eq(templates.status, "published")];
+
+    if (search) {
+      const pattern = `%${search}%`;
+      conditions.push(
+        or(
+          ilike(templates.title, pattern),
+          ilike(templates.description, pattern),
+        )!,
+      );
+    }
+
+    if (tag) {
+      conditions.push(sql`${templates.tags} ? ${tag}`);
+    }
+
+    if (destination) {
+      conditions.push(sql`${templates.destinations} ? ${destination}`);
+    }
+
+    if (minPrice !== undefined) {
+      conditions.push(gte(templates.price, minPrice.toString()));
+    }
+
+    if (maxPrice !== undefined) {
+      conditions.push(lte(templates.price, maxPrice.toString()));
+    }
+
+    if (duration !== undefined) {
+      conditions.push(eq(templates.duration, duration));
+    }
+
+    let orderBy: SQL = desc(templates.sales_count);
+    switch (sort) {
+      case "newest":
+        orderBy = desc(templates.created_at);
+        break;
+      case "price-low":
+        orderBy = asc(templates.price);
+        break;
+      case "price-high":
+        orderBy = desc(templates.price);
+        break;
+      case "popular":
+      default:
+        orderBy = desc(templates.sales_count);
+        break;
+    }
+
+    const where = and(...conditions);
+
+    return await db.select().from(templates).where(where!).orderBy(orderBy);
   }
-  
-  async updateTemplate(id: number, updates: any): Promise<Template | undefined> {
-    const [updated] = await db.update(templates)
+
+  async updateTemplate(
+    id: number,
+    updates: any,
+  ): Promise<Template | undefined> {
+    const [updated] = await db
+      .update(templates)
       .set({ ...updates, updated_at: new Date() })
       .where(eq(templates.id, id))
       .returning();
     return updated;
   }
-  
+
   async deleteTemplate(id: number): Promise<boolean> {
-    const result = await db.delete(templates).where(eq(templates.id, id)).returning({ id: templates.id });
+    const result = await db
+      .delete(templates)
+      .where(eq(templates.id, id))
+      .returning({ id: templates.id });
     return result.length > 0;
   }
-  
+
   async incrementTemplateViews(id: number): Promise<void> {
-    await db.update(templates)
+    await db
+      .update(templates)
       .set({ view_count: sql`${templates.view_count} + 1` })
       .where(eq(templates.id, id));
   }
-  
+
   // Template purchases
   async createTemplatePurchase(purchaseData: any): Promise<TemplatePurchase> {
-    const [purchase] = await db.insert(templatePurchases).values(purchaseData).returning();
-    
+    const [purchase] = await db
+      .insert(templatePurchases)
+      .values(purchaseData)
+      .returning();
+
     // Update template sales count
-    await db.update(templates)
+    await db
+      .update(templates)
       .set({ sales_count: sql`${templates.sales_count} + 1` })
       .where(eq(templates.id, purchaseData.template_id));
-    
+
     // Update creator balance
-    await this.updateCreatorBalance(purchaseData.seller_id, purchaseData.seller_earnings, 'add');
-    
+    await this.updateCreatorBalance(
+      purchaseData.seller_id,
+      purchaseData.seller_earnings,
+      "add",
+    );
+
     return purchase;
   }
-  
+
   async getTemplatePurchases(templateId: number): Promise<TemplatePurchase[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(templatePurchases)
       .where(eq(templatePurchases.template_id, templateId))
       .orderBy(desc(templatePurchases.purchased_at));
   }
-  
+
   async getUserPurchases(userId: number): Promise<TemplatePurchase[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(templatePurchases)
       .where(eq(templatePurchases.buyer_id, userId))
       .orderBy(desc(templatePurchases.purchased_at));
   }
-  
-  async hasUserPurchasedTemplate(userId: number, templateId: number): Promise<boolean> {
+
+  async hasUserPurchasedTemplate(
+    userId: number,
+    templateId: number,
+  ): Promise<boolean> {
     console.log(`Checking if user ${userId} purchased template ${templateId}`);
-    const purchases = await db.select()
+    const purchases = await db
+      .select()
       .from(templatePurchases)
-      .where(and(
-        eq(templatePurchases.buyer_id, userId),
-        eq(templatePurchases.template_id, templateId),
-        eq(templatePurchases.status, 'completed')
-      ))
+      .where(
+        and(
+          eq(templatePurchases.buyer_id, userId),
+          eq(templatePurchases.template_id, templateId),
+          eq(templatePurchases.status, "completed"),
+        ),
+      )
       .limit(1);
-    
-    console.log(`Purchase check - User: ${userId}, Template: ${templateId}, Found: ${purchases.length > 0}`);
+
+    console.log(
+      `Purchase check - User: ${userId}, Template: ${templateId}, Found: ${purchases.length > 0}`,
+    );
     if (purchases.length > 0) {
-      console.log('Found existing purchase:', purchases[0]);
+      console.log("Found existing purchase:", purchases[0]);
     }
-    
+
     return purchases.length > 0;
   }
-  
+
   // Creator profiles
   async getOrCreateCreatorProfile(userId: number): Promise<CreatorProfile> {
-    let [profile] = await db.select().from(creatorProfiles).where(eq(creatorProfiles.user_id, userId)).limit(1);
-    
+    let [profile] = await db
+      .select()
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.user_id, userId))
+      .limit(1);
+
     if (!profile) {
-      [profile] = await db.insert(creatorProfiles).values({
-        user_id: userId,
-        bio: '',
-        specialties: [],
-        verified: false,
-        featured: false,
-        follower_count: 0,
-        total_templates: 0,
-        total_sales: 0,
-      }).returning();
+      [profile] = await db
+        .insert(creatorProfiles)
+        .values({
+          user_id: userId,
+          bio: "",
+          specialties: [],
+          verified: false,
+          featured: false,
+          follower_count: 0,
+          total_templates: 0,
+          total_sales: 0,
+        })
+        .returning();
     }
-    
+
     return profile;
   }
-  
-  async updateCreatorProfile(userId: number, updates: any): Promise<CreatorProfile | undefined> {
-    const [updated] = await db.update(creatorProfiles)
+
+  async updateCreatorProfile(
+    userId: number,
+    updates: any,
+  ): Promise<CreatorProfile | undefined> {
+    const [updated] = await db
+      .update(creatorProfiles)
       .set({ ...updates, updated_at: new Date() })
       .where(eq(creatorProfiles.user_id, userId))
       .returning();
     return updated;
   }
-  
+
   async getCreatorProfile(userId: number): Promise<CreatorProfile | undefined> {
-    const [profile] = await db.select().from(creatorProfiles).where(eq(creatorProfiles.user_id, userId)).limit(1);
+    const [profile] = await db
+      .select()
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.user_id, userId))
+      .limit(1);
     return profile;
   }
-  
+
   // Creator balances
   async getOrCreateCreatorBalance(userId: number): Promise<CreatorBalance> {
-    let [balance] = await db.select().from(creatorBalances).where(eq(creatorBalances.user_id, userId)).limit(1);
-    
+    let [balance] = await db
+      .select()
+      .from(creatorBalances)
+      .where(eq(creatorBalances.user_id, userId))
+      .limit(1);
+
     if (!balance) {
-      [balance] = await db.insert(creatorBalances).values({
-        user_id: userId,
-        available_balance: '0',
-        pending_balance: '0',
-        lifetime_earnings: '0',
-        lifetime_payouts: '0',
-        total_sales: 0,
-      }).returning();
+      [balance] = await db
+        .insert(creatorBalances)
+        .values({
+          user_id: userId,
+          available_balance: "0",
+          pending_balance: "0",
+          lifetime_earnings: "0",
+          lifetime_payouts: "0",
+          total_sales: 0,
+        })
+        .returning();
     }
-    
+
     return balance;
   }
-  
-  async updateCreatorBalance(userId: number, amount: number, type: 'add' | 'subtract'): Promise<CreatorBalance> {
-    const operator = type === 'add' ? '+' : '-';
-    
-    const [updated] = await db.update(creatorBalances)
-      .set({ 
+
+  async updateCreatorBalance(
+    userId: number,
+    amount: number,
+    type: "add" | "subtract",
+  ): Promise<CreatorBalance> {
+    const operator = type === "add" ? "+" : "-";
+
+    const [updated] = await db
+      .update(creatorBalances)
+      .set({
         available_balance: sql`${creatorBalances.available_balance} ${sql.raw(operator)} ${amount}`,
-        lifetime_earnings: type === 'add' ? sql`${creatorBalances.lifetime_earnings} + ${amount}` : creatorBalances.lifetime_earnings,
-        total_sales: type === 'add' ? sql`${creatorBalances.total_sales} + 1` : creatorBalances.total_sales,
-        updated_at: new Date()
+        lifetime_earnings:
+          type === "add"
+            ? sql`${creatorBalances.lifetime_earnings} + ${amount}`
+            : creatorBalances.lifetime_earnings,
+        total_sales:
+          type === "add"
+            ? sql`${creatorBalances.total_sales} + 1`
+            : creatorBalances.total_sales,
+        updated_at: new Date(),
       })
       .where(eq(creatorBalances.user_id, userId))
       .returning();
-    
+
     if (!updated) {
       // Create balance if it doesn't exist
       await this.getOrCreateCreatorBalance(userId);
       return await this.updateCreatorBalance(userId, amount, type);
     }
-    
+
     return updated;
   }
-  
+
   async getCreatorBalance(userId: number): Promise<CreatorBalance | undefined> {
-    const [balance] = await db.select().from(creatorBalances).where(eq(creatorBalances.user_id, userId)).limit(1);
+    const [balance] = await db
+      .select()
+      .from(creatorBalances)
+      .where(eq(creatorBalances.user_id, userId))
+      .limit(1);
     return balance;
   }
-  
+
   // Template reviews
   async createTemplateReview(reviewData: any): Promise<TemplateReview> {
-    const [review] = await db.insert(templateReviews).values(reviewData).returning();
-    
+    const [review] = await db
+      .insert(templateReviews)
+      .values(reviewData)
+      .returning();
+
     // Update template rating
     await this.updateTemplateRating(reviewData.template_id);
-    
+
     return review;
   }
-  
+
   async getTemplateReviews(templateId: number): Promise<TemplateReview[]> {
-    return await db.select()
+    return await db
+      .select()
       .from(templateReviews)
       .where(eq(templateReviews.template_id, templateId))
       .orderBy(desc(templateReviews.created_at));
   }
-  
-  async getUserReview(userId: number, templateId: number): Promise<TemplateReview | undefined> {
-    const [review] = await db.select()
+
+  async getUserReview(
+    userId: number,
+    templateId: number,
+  ): Promise<TemplateReview | undefined> {
+    const [review] = await db
+      .select()
       .from(templateReviews)
-      .where(and(
-        eq(templateReviews.user_id, userId),
-        eq(templateReviews.template_id, templateId)
-      ))
+      .where(
+        and(
+          eq(templateReviews.user_id, userId),
+          eq(templateReviews.template_id, templateId),
+        ),
+      )
       .limit(1);
     return review;
   }
-  
+
   async updateTemplateRating(templateId: number): Promise<void> {
     const reviews = await this.getTemplateReviews(templateId);
     const count = reviews.length;
     const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
     const average = count > 0 ? (sum / count).toFixed(2) : null;
-    
-    await db.update(templates)
-      .set({ 
+
+    await db
+      .update(templates)
+      .set({
         rating: average,
-        review_count: count 
+        review_count: count,
       })
       .where(eq(templates.id, templateId));
   }
-  
+
   // Template sharing
   async trackTemplateShare(shareData: any): Promise<TemplateShare> {
     const shareCode = nanoid(10);
-    const [share] = await db.insert(templateShares).values({
-      ...shareData,
-      share_code: shareCode,
-      clicks: 0,
-      conversions: 0,
-      revenue_generated: '0',
-    }).returning();
-    
+    const [share] = await db
+      .insert(templateShares)
+      .values({
+        ...shareData,
+        share_code: shareCode,
+        clicks: 0,
+        conversions: 0,
+        revenue_generated: "0",
+      })
+      .returning();
+
     return share;
   }
-  
+
   async incrementShareClicks(shareCode: string): Promise<void> {
-    await db.update(templateShares)
+    await db
+      .update(templateShares)
       .set({ clicks: sql`${templateShares.clicks} + 1` })
       .where(eq(templateShares.share_code, shareCode));
   }
-  
+
   async trackShareConversion(shareCode: string): Promise<void> {
-    await db.update(templateShares)
+    await db
+      .update(templateShares)
       .set({ conversions: sql`${templateShares.conversions} + 1` })
       .where(eq(templateShares.share_code, shareCode));
   }
-  
-  async getTemplateByShareCode(shareCode: string): Promise<Template | undefined> {
+
+  async getTemplateByShareCode(
+    shareCode: string,
+  ): Promise<Template | undefined> {
     // First try to get the share record
-    const [share] = await db.select()
+    const [share] = await db
+      .select()
       .from(templateShares)
       .where(eq(templateShares.share_code, shareCode))
       .limit(1);
-    
+
     if (!share) {
       // No share record found - this might be a direct link
       // Don't track clicks for non-existent shares
       return undefined;
     }
-    
+
     // Increment click count for valid shares
     await this.incrementShareClicks(shareCode);
-    
+
     // Get the template
-    const [template] = await db.select()
+    const [template] = await db
+      .select()
       .from(templates)
       .where(eq(templates.id, share.template_id))
       .limit(1);
-    
+
     return template;
   }
-  
+
   // Helper methods
   private async generateUniqueSlug(title: string): Promise<string> {
     const baseSlug = title
       .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
     let slug = baseSlug;
     let counter = 1;
-    
+
     while (await this.getTemplateBySlug(slug)) {
       slug = `${baseSlug}-${counter}`;
       counter++;
     }
-    
+
     return slug;
   }
-  
+
   private async incrementCreatorTemplateCount(userId: number): Promise<void> {
     const profile = await this.getOrCreateCreatorProfile(userId);
-    await db.update(creatorProfiles)
+    await db
+      .update(creatorProfiles)
       .set({ total_templates: sql`${creatorProfiles.total_templates} + 1` })
       .where(eq(creatorProfiles.user_id, userId));
   }

--- a/server/stripe.ts
+++ b/server/stripe.ts
@@ -92,6 +92,7 @@ export async function createRefund(paymentIntentId: string, amount?: number, rea
 }
 
 export async function getCustomerInvoices(customerId: string) {
+  if (!stripe) throw new Error('Stripe is not configured');
   return await stripe.invoices.list({
     customer: customerId,
     limit: 10,
@@ -99,6 +100,7 @@ export async function getCustomerInvoices(customerId: string) {
 }
 
 export async function getSubscriptionDetails(subscriptionId: string) {
+  if (!stripe) throw new Error('Stripe is not configured');
   return await stripe.subscriptions.retrieve(subscriptionId, {
     expand: ['latest_invoice.payment_intent'],
   });
@@ -119,6 +121,7 @@ export async function createCardholder(params: {
     };
   };
 }) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     return await stripe.issuing.cardholders.create({
       type: 'individual',
@@ -147,6 +150,7 @@ export async function createCorporateCard(params: {
   };
   metadata?: Record<string, string>;
 }) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     return await stripe.issuing.cards.create({
       cardholder: params.cardholder,
@@ -224,6 +228,7 @@ export async function createTransaction(params: {
 }
 
 export async function getCardBalance(cardId: string) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     const card = await stripe.issuing.cards.retrieve(cardId);
     return {
@@ -238,6 +243,7 @@ export async function getCardBalance(cardId: string) {
 }
 
 export async function addFundsToCard(cardId: string, amount: number) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     // Update card spending limits to add funds
     const card = await stripe.issuing.cards.retrieve(cardId);
@@ -261,6 +267,7 @@ export async function addFundsToCard(cardId: string, amount: number) {
 }
 
 export async function freezeCard(cardId: string) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     return await stripe.issuing.cards.update(cardId, {
       status: 'inactive',
@@ -272,6 +279,7 @@ export async function freezeCard(cardId: string) {
 }
 
 export async function unfreezeCard(cardId: string) {
+  if (!stripe) throw new Error('Stripe is not configured');
   try {
     return await stripe.issuing.cards.update(cardId, {
       status: 'active',


### PR DESCRIPTION
## Summary
- query template marketplace directly with SQL filters and sorting
- add backend search with query params instead of in-memory filtering
- add database indexes to speed up template marketplace filtering
- fix type errors for template search by importing SQL helpers and guarding optional Stripe client

## Testing
- `npm run check` *(fails: cannot find module 'connect-pg-simple'; missing types and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689672af6d248323b41c217086128500