### PR TITLE
feat: add basic PWA support

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- Mapbox CSS -->
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet">
+    <meta name="theme-color" content="#4374CB" />
+    <link rel="manifest" href="/manifest.json" />
     <!-- Google Sign In -->
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,3 +13,11 @@ if (!root) {
 }
 
 createRoot(root).render(<App />);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .catch((err) => console.error('Service worker registration failed:', err));
+  });
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,39 @@
-// Service Worker for Push Notifications
+// Service Worker for PWA features and Push Notifications
+const CACHE_NAME = 'remvana-cache-v1';
+const OFFLINE_URLS = ['/', '/index.html', '/manifest.json'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.map((key) => {
+            if (key !== CACHE_NAME) {
+              return caches.delete(key);
+            }
+            return undefined;
+          })
+        )
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});
+
 self.addEventListener('push', function(event) {
   if (event.data) {
     const data = event.data.json();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(__dirname, "client"),
+  publicDir: path.resolve(__dirname, "public"),
   build: {
     outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- link web manifest and theme color in HTML
- register and configure service worker with offline caching
- expose public assets for PWA via Vite config

## Testing
- `npm test` *(fails: Missing script "test" so no tests run)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac55bd87b48323a7c6742260f10b8a